### PR TITLE
Support for zarr-ngff

### DIFF
--- a/N5Read.pyscro
+++ b/N5Read.pyscro
@@ -19,7 +19,7 @@ def split_path_at_container(path):
 
 def get_resolution_and_offset(dataset):
     resolution = [1] * dataset.ndim 
-    offset = [.5] * dataset.ndim
+    offset = [0] * dataset.ndim
     attrs = dataset.attrs
     if 'resolution' in attrs.keys() and 'offset' in attrs.keys():
         # reverse the order to make it z,y,x

--- a/ZarrRead.pyscro
+++ b/ZarrRead.pyscro
@@ -1,0 +1,194 @@
+import zarr
+from pathlib import Path
+import numpy as np
+import dask.array as da
+import os
+from typing import Union, List, Tuple
+_container_extensions = ('.zarr')
+
+def split_path_at_container(path: str):
+    # check whether a path contains a valid file path to a container file, and if so which container format it is
+    result = None, None
+    pathobj = Path(path)
+    if pathobj.suffix in _container_extensions:
+        result = [path, '']
+    else:
+        for parent in pathobj.parents:
+            if parent.suffix in _container_extensions:
+                result = path.split(parent.suffix)
+                result[0] += parent.suffix
+    return result
+
+def access_parent(node: Union[zarr.core.Array, zarr.hierarchy.Group]) -> zarr.hierarchy.Group:
+    """
+    Get the parent (zarr.Group) of an input zarr array(ds).
+    """
+    parent_path = os.path.split(node.path)[0]
+    return zarr.hierarchy.group(store=node.store, path=parent_path)
+
+def check_for_multiscale(group: zarr.hierarchy.Group) -> Tuple[dict, zarr.hierarchy.Group]:
+    """check if multiscale attribute exists in the input group and for any parent level group
+    """
+    multiscales = group.attrs.get("multiscales", None)
+
+    if multiscales:
+        return (multiscales, group)
+
+    if group.path == "":
+        return (multiscales, group)
+
+    return check_for_multiscale(access_parent(group))
+
+
+def get_resolution_and_offset(ds: zarr.core.Array,
+                               multiscales_group: Tuple[dict, zarr.hierarchy.Group]) -> Tuple[List[float], List[float], List[str]]:
+    """checks multiscale attribute of the .zarr group
+        for voxel_size(scale), offset(translation) and units values
+    """
+
+    voxel_size = [1] * ds.ndim
+    offset = [0] * ds.ndim
+    units = ["nanometer"] * ds.ndim
+    multiscales = multiscales_group[0]
+
+    if multiscales is not None:
+        print.info("Found multiscales attributes")
+        scale = os.path.split(ds.path)[1]
+        
+        if multiscales[0]["axes"]:
+            units = [item["unit"] for item in multiscales[0]["axes"]]
+        else: 
+            print("Units are not defined in multiscales. Using default: Units = {0}".format(units))
+            
+        # get s0 level voxel_size and offset
+        for level in multiscales[0]["datasets"]:
+            if level["path"].lstrip("/") == scale:
+                for attr in level["coordinateTransformations"]:
+                    if attr["type"] == "scale":
+                        voxel_size = attr["scale"]
+                    elif attr["type"] == "translation":
+                        offset = attr["translation"]
+                return voxel_size, offset, units
+    else:
+        print('Multiscales attributes not found. Using default: Resolution = {0} nm, Offset = {1} nm'.format(voxel_size, offset))
+
+    return voxel_size, offset, units
+
+
+# def get_resolution_and_offset(dataset):
+#     resolution = [1] * dataset.ndim 
+#     offset = [0] * dataset.ndim
+#     attrs = dataset.attrs
+#     if 'resolution' in attrs.keys() and 'offset' in attrs.keys():
+#         # reverse the order to make it z,y,x
+#         resolution = dataset.attrs['resolution'][::-1]
+#         offset = dataset.attrs['offset'][::-1]
+#     elif 'pixelResolution' in attrs.keys(): 
+#         resolution = dataset.attrs['pixelResolution']['dimensions']
+#         offset = [0] * len(resolution)
+#     else:
+#         print('Resolution and offset could not be determined from metadata. Using default: Resolution = {0} nm, Offset = {1} nm'.format(resolution, offset))
+#     return resolution, offset
+
+
+class ZarrRead(PyScriptObject):
+    def __init__(self):        
+        self.data.valid_types = ['HxUniformScalarField3']
+        self.do_it = HxPortDoIt(self, 'read', 'Load Zarr')
+        self.input_dir = HxPortFilename(self, 'inputDir', 'Input Directory')
+        self.input_dir.mode = HxPortFilename.LOAD_DIRECTORY
+        self.info = HxPortInfo(self, 'array_info', 'Array info')
+        self.container = None
+        self.dataset = None
+        self.container_path = None
+        self.dataset_path = None
+        self.resolution = None
+        self.offset = None
+        self.units = None
+
+
+        self._dimensions = ('z', 'y', 'x')
+        self.slice_textboxes = dict()
+        self.update_info_box()        
+        
+        for dim in self._dimensions:
+            dim_disp = dim.upper()
+            self.slice_textboxes[dim] = HxPortIntTextN(self, 
+                                                       label='{0} limits'.format(dim_disp), 
+                                                       name='{0}_lims'.format(dim))
+                    
+            self.slice_textboxes[dim].texts = [HxPortIntTextN.IntText(label="Start", 
+                                                                      value=0),
+                                               HxPortIntTextN.IntText(label="Stop", 
+                                                                      value=0)]
+                
+        self.slices = {d: slice(0, 1) for d in self._dimensions} 
+    
+
+    def update(self):
+        if self.input_dir.is_new and self.input_dir.filenames is not None:
+            self.container_path, self.dataset_path = split_path_at_container(self.input_dir.filenames)
+            if self.container_path is None:
+                hx_message.error(message='You have not selected a folder that represents a Zarr array.')
+                return
+            self.container = self.access_container(mode='r')
+            self.dataset = self.container[self.dataset_path]
+            # validate that user selected a dataset
+            if not isinstance(self.dataset, zarr.core.Array):
+                hx_message.error(message='You have not selected a folder that represents a Zarr array.')
+                return
+                
+            self.resolution, self.offset, self.units = get_resolution_and_offset(self.dataset, check_for_multiscale(access_parent(self.dataset)))
+            self.update_info_box()
+            for ind, dim in enumerate(self._dimensions):
+                for tb in self.slice_textboxes[dim].texts:
+                    tb.clamp_range = (0, self.dataset.shape[::-1][ind])
+
+            assert len(self.dataset.shape) == 3
+        
+        # if any of the textboxes have changed, then update the corresponding slices
+        if any(s.is_new for s in self.slice_textboxes.values()):
+            for d in self._dimensions:
+               self.slices[d] = slice(self.slice_textboxes[d].texts[0].value, self.slice_textboxes[d].texts[1].value)          
+        pass
+
+    def update_info_box(self):
+        if isinstance(self.dataset, zarr.core.Array):
+            self.info.text = '{0} array with shape {1}'.format(self.dataset.dtype, self.dataset.shape[::-1])        
+        else:
+            self.info.text = 'No array selected'
+
+    
+    def access_container(self, mode):       
+        store_path = None
+        store_path = self.container_path
+        container = zarr.open(store=store_path, mode=mode)
+        return container
+
+    def compute(self):
+        
+        if not self.do_it.was_hit:
+            return
+
+        result = hx_project.create('HxUniformScalarField3')
+        slices_ = tuple(self.slices[d] for d in self._dimensions)[::-1]
+        array = da.from_array(self.container[self.dataset_path])[slices_].compute().T
+        shape_native_res = ((s-1) * r for s, r in zip(array.shape, self.resolution[::-1]))
+        
+        # amira doesn't like numpy uint64 or uint32
+        if array.dtype in (np.dtype('uint64'), np.dtype('uint32')):
+            array = array.astype('uint16')
+        if array.dtype == np.dtype('int64'):
+            array = array.astype('int32')
+        
+        # for a 3D array with dimensions numbered [0,1,2], amira assigns named dimensions ['x','y','z'] 
+        # so everything has to be flipped relative to the pythonic indexing scheme
+        # in amira, the bounding box defines the pixel size and position in space of the data. So we set the bounding box and origin in nanometers.
+        bbox_starts = tuple((r * s.start) + o for r, s, o in zip(self.resolution, slices_, self.offset))[::-1]
+        bbox_stops = tuple(o + s for o, s in zip(bbox_starts, shape_native_res)) 
+
+        result.bounding_box = bbox_starts, bbox_stops
+        result.set_array(array)
+        result.name = self.dataset_path
+        # connect the resulting 3D data to the zarr loader object
+        result.ports.master.connect(hx_project.get(self.name))

--- a/ZarrRead.pyscro
+++ b/ZarrRead.pyscro
@@ -74,23 +74,6 @@ def get_resolution_and_offset(ds: zarr.core.Array,
 
     return voxel_size, offset, units
 
-
-# def get_resolution_and_offset(dataset):
-#     resolution = [1] * dataset.ndim 
-#     offset = [0] * dataset.ndim
-#     attrs = dataset.attrs
-#     if 'resolution' in attrs.keys() and 'offset' in attrs.keys():
-#         # reverse the order to make it z,y,x
-#         resolution = dataset.attrs['resolution'][::-1]
-#         offset = dataset.attrs['offset'][::-1]
-#     elif 'pixelResolution' in attrs.keys(): 
-#         resolution = dataset.attrs['pixelResolution']['dimensions']
-#         offset = [0] * len(resolution)
-#     else:
-#         print('Resolution and offset could not be determined from metadata. Using default: Resolution = {0} nm, Offset = {1} nm'.format(resolution, offset))
-#     return resolution, offset
-
-
 class ZarrRead(PyScriptObject):
     def __init__(self):        
         self.data.valid_types = ['HxUniformScalarField3']
@@ -107,7 +90,7 @@ class ZarrRead(PyScriptObject):
         self.units = None
 
 
-        self._dimensions = ('z', 'y', 'x')
+        self._dimensions = ('x', 'y', 'z')
         self.slice_textboxes = dict()
         self.update_info_box()        
         
@@ -135,7 +118,7 @@ class ZarrRead(PyScriptObject):
             self.dataset = self.container[self.dataset_path]
             # validate that user selected a dataset
             if not isinstance(self.dataset, zarr.core.Array):
-                hx_message.error(message=f('You have not selected a folder that represents a Zarr array.'))
+                hx_message.error(message='You have not selected a folder that represents a Zarr array.')
                 return
             self.resolution, self.offset, self.units = get_resolution_and_offset(self.dataset, check_for_multiscale(access_parent(self.dataset)))
             self.update_info_box()

--- a/ZarrRead.pyscro
+++ b/ZarrRead.pyscro
@@ -129,19 +129,16 @@ class ZarrRead(PyScriptObject):
         if self.input_dir.is_new and self.input_dir.filenames is not None:
             self.container_path, self.dataset_path = split_path_at_container(self.input_dir.filenames)
             if self.container_path is None:
-                hx_message.error(message='You have not selected a folder that represents a Zarr array  aaaaaa.')
+                hx_message.error(message='You have not selected a folder that represents a Zarr array.')
                 return
             self.container = self.access_container(mode='r')
             self.dataset = self.container[self.dataset_path]
             # validate that user selected a dataset
             if not isinstance(self.dataset, zarr.core.Array):
-                hx_message.error(message=f'self.container_path={self.container_path},self.dataset_path={self.dataset_path}, self.dataset={type(self.dataset)}, self.container={type(self.container)}, self.dataset_path={type(self.dataset_path)} You have not selected a folder that represents a Zarr array bbbbbbb.')
+                hx_message.error(message=f('You have not selected a folder that represents a Zarr array.'))
                 return
-            #hx_message.error(message="1")
             self.resolution, self.offset, self.units = get_resolution_and_offset(self.dataset, check_for_multiscale(access_parent(self.dataset)))
-            hx_message.error(message="2")
             self.update_info_box()
-            hx_message.error(message="3")
             for ind, dim in enumerate(self._dimensions):
                 for tb in self.slice_textboxes[dim].texts:
                     tb.clamp_range = (0, self.dataset.shape[::-1][ind])

--- a/ZarrRead.pyscro
+++ b/ZarrRead.pyscro
@@ -4,17 +4,17 @@ import numpy as np
 import dask.array as da
 import os
 from typing import Union, List, Tuple
-_container_extensions = ('.zarr')
+_container_extension = '.zarr'
 
 def split_path_at_container(path: str):
     # check whether a path contains a valid file path to a container file, and if so which container format it is
     result = None, None
     pathobj = Path(path)
-    if pathobj.suffix in _container_extensions:
+    if pathobj.suffix==_container_extension:
         result = [path, '']
     else:
         for parent in pathobj.parents:
-            if parent.suffix in _container_extensions:
+            if parent.suffix==_container_extension:
                 result = path.split(parent.suffix)
                 result[0] += parent.suffix
     return result
@@ -52,7 +52,7 @@ def get_resolution_and_offset(ds: zarr.core.Array,
     multiscales = multiscales_group[0]
 
     if multiscales is not None:
-        print.info("Found multiscales attributes")
+        print("Found multiscales attributes")
         scale = os.path.split(ds.path)[1]
         
         if multiscales[0]["axes"]:
@@ -129,17 +129,19 @@ class ZarrRead(PyScriptObject):
         if self.input_dir.is_new and self.input_dir.filenames is not None:
             self.container_path, self.dataset_path = split_path_at_container(self.input_dir.filenames)
             if self.container_path is None:
-                hx_message.error(message='You have not selected a folder that represents a Zarr array.')
+                hx_message.error(message='You have not selected a folder that represents a Zarr array  aaaaaa.')
                 return
             self.container = self.access_container(mode='r')
             self.dataset = self.container[self.dataset_path]
             # validate that user selected a dataset
             if not isinstance(self.dataset, zarr.core.Array):
-                hx_message.error(message='You have not selected a folder that represents a Zarr array.')
+                hx_message.error(message=f'self.container_path={self.container_path},self.dataset_path={self.dataset_path}, self.dataset={type(self.dataset)}, self.container={type(self.container)}, self.dataset_path={type(self.dataset_path)} You have not selected a folder that represents a Zarr array bbbbbbb.')
                 return
-                
+            #hx_message.error(message="1")
             self.resolution, self.offset, self.units = get_resolution_and_offset(self.dataset, check_for_multiscale(access_parent(self.dataset)))
+            hx_message.error(message="2")
             self.update_info_box()
+            hx_message.error(message="3")
             for ind, dim in enumerate(self._dimensions):
                 for tb in self.slice_textboxes[dim].texts:
                     tb.clamp_range = (0, self.dataset.shape[::-1][ind])
@@ -160,8 +162,7 @@ class ZarrRead(PyScriptObject):
 
     
     def access_container(self, mode):       
-        store_path = None
-        store_path = self.container_path
+        store_path = zarr.NestedDirectoryStore(self.container_path)
         container = zarr.open(store=store_path, mode=mode)
         return container
 

--- a/ZarrRead.rc
+++ b/ZarrRead.rc
@@ -1,0 +1,10 @@
+#############################################################
+# .rc for pyscro ZarrRead
+#############################################################
+
+module -name "ZarrRead" \
+-language "python" \
+-file "share/python_script_objects/ZarrRead.pyscro" \
+-primary "HxUniformScalarField3" \
+-package "py_core" \
+-category "{Python Scripts}"

--- a/ZarrWrite.pyscro
+++ b/ZarrWrite.pyscro
@@ -51,33 +51,7 @@ class ZarrWrite(PyScriptObject):
         # zarr
         self.slices = self.bbox_to_slices()
         output = self.data.source().get_array().T
-        # print("locals #2")
-        # print(locals())
-        # #print(self.data.__dict__)
-        # print(dir(self.data))
-        # print(dir(self.data.source()))
-        # print(self.data.source().parameters)
-        # print(self.data.source().name)
-        # print(self.data.source().portnames)
-        # print(self.data.source().ports)
-        # print(dir(self.data.source().ports.PhysicalSize))
-        # print(self.data.source().ports.PhysicalSize._get_state())
-        # print(self.data.source().ports.PhysicalSize.label)
-        # print(self.data.source().ports.PhysicalSize.text)
-        # print(self.data.source().ports.VoxelSize.label)
-        # print(self.data.source().ports.VoxelSize.text)
-
-        # print(self.data.source().range)
-
-        # print(self.data.source().get_all_interface_names())
-        # print(self.data.source().__dict__)
-        # offset values (z, y, x order) 
-        offset = self.data.source().ports.PhysicalSize.text.split('from')[1].strip().split(', ')
-        # voxel size (z, y, x order)
-        voxel_size = self.data.source().ports.VoxelSize.text.split(" x ")[::-1]
-        #dataset name 
         ds_name = self.data.source().name.strip('-')
-
 
         print('Preparing to save {0} to {1} using slices {2}'.format(output, self.dataset, self.slices))        
         self.dataset[ds_name] = output

--- a/ZarrWrite.pyscro
+++ b/ZarrWrite.pyscro
@@ -31,11 +31,12 @@ class ZarrWrite(PyScriptObject):
 
     def update(self):
         if self.output_dir.is_new and self.output_dir.filenames is not None:
-            print(self.output_dir.filenames)
             if ".zarr" in self.output_dir.filenames:
                 self.container_path, self.dataset_path = split_path_at_container(self.output_dir.filenames)
             else:
-                self.container_path = os.path.join(self.output_dir.filenames, 'amira_export.zarr')
+                dir_path = self.output_dir.filenames
+                container_name = 'amira_export'
+                self.container_path = self.if_name_exists(dir_path, container_name, 0)
                 self.dataset_path = ''
             self.container = self.access_container(mode='a')
             self.dataset = self.container[self.dataset_path]
@@ -93,7 +94,7 @@ class ZarrWrite(PyScriptObject):
         new_store, path_prefix = os.path.split(store)
         if ".zarr" in path_prefix or ".n5" in path_prefix:
             return store, path
-        return self.separate_store_path(new_store, os.path.join(path_prefix, path))
+        return self.separate_store_path(new_store, os.path.join(path_prefix, path).replace("\\","/"))
 
     def access_parent(self, node):
         store_path, node_path = self.separate_store_path(node.store.path, node.path)
@@ -103,6 +104,16 @@ class ZarrWrite(PyScriptObject):
             )
         else:
             return zarr.open(store=store_path, path=os.path.split(node_path)[0], mode="a")
+        
+    def if_name_exists(self, path, zarr_name, copy_num):
+        if copy_num == 0:
+            zarr_path=os.path.join(path, f"{zarr_name}.zarr").replace("\\","/")
+        else:
+            zarr_path= os.path.join(path,f"{zarr_name}_({copy_num}).zarr").replace("\\","/")
+        if not os.path.exists(zarr_path):
+            return zarr_path
+        else:
+            return self.if_name_exists(path, zarr_name, copy_num+1)
     
     def add_multiscales_metadata(self, z_group, ds_name):
         # default order - z, y, x

--- a/ZarrWrite.pyscro
+++ b/ZarrWrite.pyscro
@@ -59,20 +59,18 @@ class ZarrWrite(PyScriptObject):
             self.add_multiscales_metadata(self.dataset, ds_name)
             print("Added voxel size and offset attributes")
             print('Save complete')
-
+            
         elif isinstance(self.dataset, zarr.Array):
             if self.dataset.shape==output.shape:
                 print('Preparing to save {0} to {1}'.format(output, self.dataset))
                 parent_group = self.access_parent(self.dataset)
-                self.dataset=output#[self.slices[::-1]] = output
                 ds_name = self.dataset.name
+                parent_group[ds_name]=output
                 self.add_multiscales_metadata(parent_group, ds_name)
                 print("Added voxel size and offset attributes")
                 print('Save complete')
             else:
                 hx_message.error(message="You're trying to store the amira array in the dataset with different dimensions")
-
-
 
     def bbox_to_slices(self):
         # convert the bounding box of the input data (real units) to a tuple of slices (indices)

--- a/ZarrWrite.pyscro
+++ b/ZarrWrite.pyscro
@@ -1,17 +1,16 @@
 import zarr
 from pathlib import Path
-_container_extensions = ('.zarr')
-
+_container_extension = '.zarr'
 
 def split_path_at_container(path: str):
     # check whether a path contains a valid file path to a container file, and if so which container format it is
-    result = None
+    result = None, None
     pathobj = Path(path)
-    if pathobj.suffix in _container_extensions:
+    if pathobj.suffix==_container_extension:
         result = [path, '']
     else:
         for parent in pathobj.parents:
-            if parent.suffix in _container_extensions:
+            if parent.suffix==_container_extension:
                 result = path.split(parent.suffix)
                 result[0] += parent.suffix
     return result
@@ -37,7 +36,7 @@ class ZarrWrite(PyScriptObject):
         pass
 
     def access_container(self, mode):       
-        store_path = self.container_path
+        store_path = zarr.NestedDirectoryStore(self.container_path)
         container = zarr.open(store=store_path, mode=mode)
         return container
 
@@ -51,7 +50,7 @@ class ZarrWrite(PyScriptObject):
         self.slices = self.bbox_to_slices()
         output = self.data.source().get_array().T
         print('Preparing to save {0} to {1} using slices {2}'.format(output, self.dataset, self.slices))        
-        self.dataset[self.slices[::-1]] = output
+        self.dataset['s0'] = output
         print('Save complete')
 
     def bbox_to_slices(self):

--- a/ZarrWrite.pyscro
+++ b/ZarrWrite.pyscro
@@ -27,6 +27,8 @@ class ZarrWrite(PyScriptObject):
         self.container_path = None
         self.dataset_path = None        
         self.slices = None
+        print("locals #1")
+        print(locals())
 
     def update(self):
         if self.output_dir.is_new and self.output_dir.filenames is not None:
@@ -49,9 +51,16 @@ class ZarrWrite(PyScriptObject):
         # zarr
         self.slices = self.bbox_to_slices()
         output = self.data.source().get_array().T
+
+        #dataset name 
+        ds_name = self.data.source().name.strip('-')
+        
         print('Preparing to save {0} to {1} using slices {2}'.format(output, self.dataset, self.slices))        
-        self.dataset['s0'] = output
+        self.dataset[ds_name] = output
+        self.add_multiscales_metadata(output)
+        print("Added voxel size and offset attributes")
         print('Save complete')
+
 
     def bbox_to_slices(self):
         # convert the bounding box of the input data (real units) to a tuple of slices (indices)
@@ -62,3 +71,36 @@ class ZarrWrite(PyScriptObject):
         origins = tuple(int(bsta / r) for bsta, r in zip(bbox_starts, rscale))
         slices = tuple(slice(o, o + s) for o,s in zip(origins, shape))
         return slices
+    
+    def add_multiscales_metadata(self, output_arr):
+        # dataset name
+        ds_name = self.data.source().name.strip('-')
+        # default order - z, y, x
+        axes = ['z', 'y', 'x']
+        #default units - nm
+        unit = 'nanometer'
+        # offset values, z, y, x order
+        offset = self.data.source().ports.PhysicalSize.text.split('from')[1].strip().split(', ')
+        # voxel size, z, y, x order
+        voxel_size = self.data.source().ports.VoxelSize.text.split(" x ")[::-1]        
+        z_attrs: dict = {"multiscales": [{}]}
+        z_attrs["multiscales"][0]["axes"] = [
+            {"name": axis, "type": "space", "unit": unit} for axis in axes
+        ]
+        z_attrs["multiscales"][0]["coordinateTransformations"] = [
+            {"scale": [1.0, 1.0, 1.0], "type": "scale"}
+        ]
+        z_attrs["multiscales"][0]["datasets"] = [
+            {
+                "coordinateTransformations": [
+                    {"scale": voxel_size, "type": "scale"},
+                    {"translation": offset, "type": "translation"},
+                ],
+                "path": ds_name,
+            }
+        ]
+
+        z_attrs["multiscales"][0]["name"] = ""
+        z_attrs["multiscales"][0]["version"] = "0.4"
+
+        self.dataset.attrs.update(z_attrs)

--- a/ZarrWrite.pyscro
+++ b/ZarrWrite.pyscro
@@ -31,7 +31,12 @@ class ZarrWrite(PyScriptObject):
 
     def update(self):
         if self.output_dir.is_new and self.output_dir.filenames is not None:
-            self.container_path, self.dataset_path = split_path_at_container(self.output_dir.filenames)
+            print(self.output_dir.filenames)
+            if ".zarr" in self.output_dir.filenames:
+                self.container_path, self.dataset_path = split_path_at_container(self.output_dir.filenames)
+            else:
+                self.container_path = os.path.join(self.output_dir.filenames, 'amira_export.zarr')
+                self.dataset_path = 's0'
             self.container = self.access_container(mode='a')
             self.dataset = self.container[self.dataset_path]
         pass

--- a/ZarrWrite.pyscro
+++ b/ZarrWrite.pyscro
@@ -51,10 +51,34 @@ class ZarrWrite(PyScriptObject):
         # zarr
         self.slices = self.bbox_to_slices()
         output = self.data.source().get_array().T
+        # print("locals #2")
+        # print(locals())
+        # #print(self.data.__dict__)
+        # print(dir(self.data))
+        # print(dir(self.data.source()))
+        # print(self.data.source().parameters)
+        # print(self.data.source().name)
+        # print(self.data.source().portnames)
+        # print(self.data.source().ports)
+        # print(dir(self.data.source().ports.PhysicalSize))
+        # print(self.data.source().ports.PhysicalSize._get_state())
+        # print(self.data.source().ports.PhysicalSize.label)
+        # print(self.data.source().ports.PhysicalSize.text)
+        # print(self.data.source().ports.VoxelSize.label)
+        # print(self.data.source().ports.VoxelSize.text)
 
+        # print(self.data.source().range)
+
+        # print(self.data.source().get_all_interface_names())
+        # print(self.data.source().__dict__)
+        # offset values (z, y, x order) 
+        offset = self.data.source().ports.PhysicalSize.text.split('from')[1].strip().split(', ')
+        # voxel size (z, y, x order)
+        voxel_size = self.data.source().ports.VoxelSize.text.split(" x ")[::-1]
         #dataset name 
         ds_name = self.data.source().name.strip('-')
-        
+
+
         print('Preparing to save {0} to {1} using slices {2}'.format(output, self.dataset, self.slices))        
         self.dataset[ds_name] = output
         self.add_multiscales_metadata(output)
@@ -93,8 +117,8 @@ class ZarrWrite(PyScriptObject):
         z_attrs["multiscales"][0]["datasets"] = [
             {
                 "coordinateTransformations": [
-                    {"scale": voxel_size, "type": "scale"},
-                    {"translation": offset, "type": "translation"},
+                    {"scale": [float(i) for i in voxel_size], "type": "scale"},
+                    {"translation": [float(i) for i in offset], "type": "translation"},
                 ],
                 "path": ds_name,
             }

--- a/ZarrWrite.pyscro
+++ b/ZarrWrite.pyscro
@@ -55,7 +55,8 @@ class ZarrWrite(PyScriptObject):
         if isinstance(self.dataset, zarr.Group):   
             print('Saving {0} to {1}'.format(ds_name, self.dataset.name))     
             self.dataset[ds_name] = output
-            self.add_multiscales_metadata(self.dataset)
+            ds_name = self.data.source().name.strip('-')
+            self.add_multiscales_metadata(self.dataset, ds_name)
             print("Added voxel size and offset attributes")
             print('Save complete')
 
@@ -64,7 +65,8 @@ class ZarrWrite(PyScriptObject):
                 print('Preparing to save {0} to {1}'.format(output, self.dataset))
                 parent_group = self.access_parent(self.dataset)
                 self.dataset=output#[self.slices[::-1]] = output
-                self.add_multiscales_metadata(parent_group)
+                ds_name = self.dataset.name
+                self.add_multiscales_metadata(parent_group, ds_name)
                 print("Added voxel size and offset attributes")
                 print('Save complete')
             else:
@@ -99,9 +101,7 @@ class ZarrWrite(PyScriptObject):
         else:
             return zarr.open(store=store_path, path=os.path.split(node_path)[0], mode="a")
     
-    def add_multiscales_metadata(self, z_group):
-        # dataset name
-        ds_name = self.data.source().name.strip('-')
+    def add_multiscales_metadata(self, z_group, ds_name):
         # default order - z, y, x
         axes = ['z', 'y', 'x']
         #default units - nm

--- a/ZarrWrite.pyscro
+++ b/ZarrWrite.pyscro
@@ -36,7 +36,7 @@ class ZarrWrite(PyScriptObject):
                 self.container_path, self.dataset_path = split_path_at_container(self.output_dir.filenames)
             else:
                 self.container_path = os.path.join(self.output_dir.filenames, 'amira_export.zarr')
-                self.dataset_path = 's0'
+                self.dataset_path = ''
             self.container = self.access_container(mode='a')
             self.dataset = self.container[self.dataset_path]
         pass

--- a/ZarrWrite.pyscro
+++ b/ZarrWrite.pyscro
@@ -1,0 +1,65 @@
+import zarr
+from pathlib import Path
+_container_extensions = ('.zarr')
+
+
+def split_path_at_container(path: str):
+    # check whether a path contains a valid file path to a container file, and if so which container format it is
+    result = None
+    pathobj = Path(path)
+    if pathobj.suffix in _container_extensions:
+        result = [path, '']
+    else:
+        for parent in pathobj.parents:
+            if parent.suffix in _container_extensions:
+                result = path.split(parent.suffix)
+                result[0] += parent.suffix
+    return result
+
+
+class ZarrWrite(PyScriptObject):
+    def __init__(self):
+        self.data.valid_types = ['HxUniformScalarField3']                
+        self.do_it = HxPortDoIt(self, 'write', 'Save Zarr')
+        self.output_dir = HxPortFilename(self, 'outputDir', 'Output Directory')
+        self.output_dir.mode = HxPortFilename.LOAD_DIRECTORY
+        self.container = None
+        self.dataset = None
+        self.container_path = None
+        self.dataset_path = None        
+        self.slices = None
+
+    def update(self):
+        if self.output_dir.is_new and self.output_dir.filenames is not None:
+            self.container_path, self.dataset_path = split_path_at_container(self.output_dir.filenames)
+            self.container = self.access_container(mode='a')
+            self.dataset = self.container[self.dataset_path]
+        pass
+
+    def access_container(self, mode):       
+        store_path = self.container_path
+        container = zarr.open(store=store_path, mode=mode)
+        return container
+
+    def compute(self):
+        if not self.do_it.was_hit:
+            return
+        if self.data.source() is None:
+            return    
+        # Slices and array have to be transposed b/c amira uses x,y,z axis ordering but we use z,y,x for 
+        # zarr
+        self.slices = self.bbox_to_slices()
+        output = self.data.source().get_array().T
+        print('Preparing to save {0} to {1} using slices {2}'.format(output, self.dataset, self.slices))        
+        self.dataset[self.slices[::-1]] = output
+        print('Save complete')
+
+    def bbox_to_slices(self):
+        # convert the bounding box of the input data (real units) to a tuple of slices (indices)
+        shape = self.data.source().get_array().shape
+        bbox_starts, bbox_stops = self.data.source().bounding_box
+        # figure out the sampling resolution by dividing the extent of the data by its shape for each axis
+        rscale = tuple((bsto - bsta) / (s - 1) for bsto, bsta, s in zip(bbox_stops, bbox_starts, shape))
+        origins = tuple(int(bsta / r) for bsta, r in zip(bbox_starts, rscale))
+        slices = tuple(slice(o, o + s) for o,s in zip(origins, shape))
+        return slices

--- a/ZarrWrite.pyscro
+++ b/ZarrWrite.pyscro
@@ -1,5 +1,6 @@
 import zarr
 from pathlib import Path
+import os
 _container_extension = '.zarr'
 
 def split_path_at_container(path: str):
@@ -27,8 +28,6 @@ class ZarrWrite(PyScriptObject):
         self.container_path = None
         self.dataset_path = None        
         self.slices = None
-        print("locals #1")
-        print(locals())
 
     def update(self):
         if self.output_dir.is_new and self.output_dir.filenames is not None:
@@ -53,11 +52,24 @@ class ZarrWrite(PyScriptObject):
         output = self.data.source().get_array().T
         ds_name = self.data.source().name.strip('-')
 
-        print('Preparing to save {0} to {1} using slices {2}'.format(output, self.dataset, self.slices))        
-        self.dataset[ds_name] = output
-        self.add_multiscales_metadata(output)
-        print("Added voxel size and offset attributes")
-        print('Save complete')
+        if isinstance(self.dataset, zarr.Group):   
+            print('Saving {0} to {1}'.format(ds_name, self.dataset.name))     
+            self.dataset[ds_name] = output
+            self.add_multiscales_metadata(self.dataset)
+            print("Added voxel size and offset attributes")
+            print('Save complete')
+
+        elif isinstance(self.dataset, zarr.Array):
+            if self.dataset.shape==output.shape:
+                print('Preparing to save {0} to {1}'.format(output, self.dataset))
+                parent_group = self.access_parent(self.dataset)
+                self.dataset=output#[self.slices[::-1]] = output
+                self.add_multiscales_metadata(parent_group)
+                print("Added voxel size and offset attributes")
+                print('Save complete')
+            else:
+                hx_message.error(message="You're trying to store the amira array in the dataset with different dimensions")
+
 
 
     def bbox_to_slices(self):
@@ -70,7 +82,24 @@ class ZarrWrite(PyScriptObject):
         slices = tuple(slice(o, o + s) for o,s in zip(origins, shape))
         return slices
     
-    def add_multiscales_metadata(self, output_arr):
+
+    def separate_store_path(self, store, path):
+   
+        new_store, path_prefix = os.path.split(store)
+        if ".zarr" in path_prefix or ".n5" in path_prefix:
+            return store, path
+        return self.separate_store_path(new_store, os.path.join(path_prefix, path))
+
+    def access_parent(self, node):
+        store_path, node_path = self.separate_store_path(node.store.path, node.path)
+        if node_path == "":
+            raise RuntimeError(
+                f"{node.name} is in the root group of the {node.store.path} store."
+            )
+        else:
+            return zarr.open(store=store_path, path=os.path.split(node_path)[0], mode="a")
+    
+    def add_multiscales_metadata(self, z_group):
         # dataset name
         ds_name = self.data.source().name.strip('-')
         # default order - z, y, x
@@ -78,7 +107,7 @@ class ZarrWrite(PyScriptObject):
         #default units - nm
         unit = 'nanometer'
         # offset values, z, y, x order
-        offset = self.data.source().ports.PhysicalSize.text.split('from')[1].strip().split(', ')
+        offset = self.data.source().ports.PhysicalSize.text.split('from')[1].strip().split(', ')[::-1]
         # voxel size, z, y, x order
         voxel_size = self.data.source().ports.VoxelSize.text.split(" x ")[::-1]        
         z_attrs: dict = {"multiscales": [{}]}
@@ -101,4 +130,7 @@ class ZarrWrite(PyScriptObject):
         z_attrs["multiscales"][0]["name"] = ""
         z_attrs["multiscales"][0]["version"] = "0.4"
 
-        self.dataset.attrs.update(z_attrs)
+       
+        z_group.attrs.update(z_attrs)
+        
+

--- a/ZarrWrite.rc
+++ b/ZarrWrite.rc
@@ -1,0 +1,10 @@
+#############################################################
+# .rc for pyscro ZarrWrite
+#############################################################
+
+module -name "ZarrWrite" \
+-language "python" \
+-file "share/python_script_objects/ZarrWrite.pyscro" \
+-primary "HxUniformScalarField3" \
+-package "py_core" \
+-category "{Python Scripts}"


### PR DESCRIPTION
ZarrRead.pyscro - a module for reading arrays from zarr containers and voxel size and offset values stored in .zattrs.
ZarrWrite.pyscro - a module for storing an amira array in a zarr container and adding metadata to the multiscale attribute in .zattrs