### PR TITLE
add support for both zarr v2 and zarr v3 with tensorstore

### DIFF
--- a/ZarrRead.pyscro
+++ b/ZarrRead.pyscro
@@ -173,7 +173,6 @@ class ZarrRead(PyScriptObject):
                 self.resolution = self.resolution[-3:]
                 self.offset = self.offset[-3:]
                 self.units = self.units[-3:]
-                self.channel.texts[0].clamp_range = (0, self.dataset.shape[0] - 1)
             else:
                 self.channel.texts[0].clamp_range = (0, 0)
             self.update_info_box()

--- a/ZarrRead.pyscro
+++ b/ZarrRead.pyscro
@@ -229,7 +229,7 @@ class ZarrRead(PyScriptObject):
         result = hx_project.create('HxUniformScalarField3')
         ts_slices = (ch,) + spatial_slices if self.ndim == 4 else spatial_slices
         array = self.dataset[ts_slices].read().result().T
-        shape_native_res = (s * r for s, r in zip(array.shape, self.resolution[::-1]))
+        shape_native_res = ((s - 1) * r for s, r in zip(array.shape, self.resolution[::-1]))
 
         if array.dtype in (np.dtype('uint64'), np.dtype('uint32')):
             array = array.astype('uint16')

--- a/ZarrRead.pyscro
+++ b/ZarrRead.pyscro
@@ -191,7 +191,7 @@ class ZarrRead(PyScriptObject):
             elif self.ndim == 4:
                 max_ch = self.dataset.shape[0] - 1
                 if ch < 0 or ch > max_ch:
-                    hx_message.error(message='Channel index out of range. Choose within 0–{0}.'.format(max_ch))
+                    hx_message.error(message='Channel index out of range. Choose within 0-{0}.'.format(max_ch))
 
         # if any of the textboxes have changed, then update the corresponding slices
         if any(s.is_new for s in self.slice_textboxes.values()):
@@ -213,7 +213,6 @@ class ZarrRead(PyScriptObject):
             hx_message.error(message='No array selected. Please choose a Zarr array first.')
             return
 
-        result = hx_project.create('HxUniformScalarField3')
         ch = self.channel.texts[0].value
         if self.ndim == 3 and ch != 0:
             hx_message.error(message='Channel index must be 0 for a 3D array.')
@@ -227,6 +226,7 @@ class ZarrRead(PyScriptObject):
         if any(sl.start == sl.stop for sl in spatial_slices):
             hx_message.error(message='Start and stop limits are the same along one of the (X, Y, Z) dimensions.')
             return
+        result = hx_project.create('HxUniformScalarField3')
         ts_slices = (ch,) + spatial_slices if self.ndim == 4 else spatial_slices
         array = self.dataset[ts_slices].read().result().T
         shape_native_res = ((s - 1) * r for s, r in zip(array.shape, self.resolution[::-1]))

--- a/ZarrRead.pyscro
+++ b/ZarrRead.pyscro
@@ -96,7 +96,8 @@ def get_resolution_and_offset(array_dir: str, ndim: int,
         rel_path = os.path.basename(array_dir)
 
     if multiscales[0].get('axes'):
-        units = [item['unit'] for item in multiscales[0]['axes']]
+        units = [item.get('unit', '' if item.get('type') == 'channel' else 'nanometer')
+                 for item in multiscales[0]['axes']]
     else:
         print('Units not defined in multiscales. Using default: {0}'.format(units))
 

--- a/ZarrRead.pyscro
+++ b/ZarrRead.pyscro
@@ -184,11 +184,19 @@ class ZarrRead(PyScriptObject):
                 self.slice_textboxes[dim].texts[1].value = size
                 self.slices[dim] = slice(0, size)
         
+        if self.channel.is_new and self.ndim is not None:
+            ch = self.channel.texts[0].value
+            if self.ndim == 3 and ch != 0:
+                hx_message.error(message='Channel index must be 0 for a 3D array.')
+            elif self.ndim == 4:
+                max_ch = self.dataset.shape[0] - 1
+                if ch < 0 or ch > max_ch:
+                    hx_message.error(message='Channel index out of range. Choose within 0–{0}.'.format(max_ch))
+
         # if any of the textboxes have changed, then update the corresponding slices
         if any(s.is_new for s in self.slice_textboxes.values()):
             for d in self._dimensions:
-               self.slices[d] = slice(self.slice_textboxes[d].texts[0].value, self.slice_textboxes[d].texts[1].value)          
-        pass
+               self.slices[d] = slice(self.slice_textboxes[d].texts[0].value, self.slice_textboxes[d].texts[1].value)
 
     def update_info_box(self):
         if self.dataset is not None:

--- a/ZarrRead.pyscro
+++ b/ZarrRead.pyscro
@@ -229,7 +229,7 @@ class ZarrRead(PyScriptObject):
         result = hx_project.create('HxUniformScalarField3')
         ts_slices = (ch,) + spatial_slices if self.ndim == 4 else spatial_slices
         array = self.dataset[ts_slices].read().result().T
-        shape_native_res = ((s - 1) * r for s, r in zip(array.shape, self.resolution[::-1]))
+        shape_native_res = (s * r for s, r in zip(array.shape, self.resolution[::-1]))
 
         if array.dtype in (np.dtype('uint64'), np.dtype('uint32')):
             array = array.astype('uint16')

--- a/ZarrRead.pyscro
+++ b/ZarrRead.pyscro
@@ -1,7 +1,6 @@
-import zarr
+import tensorstore as ts
 from pathlib import Path
 import numpy as np
-import dask.array as da
 import os
 import json
 from typing import List, Tuple, Optional
@@ -48,6 +47,24 @@ def read_attrs(path: str) -> dict:
         meta = json.loads((p / 'zarr.json').read_text())
         return meta.get('attributes', {})
     return {}
+
+
+def open_ts_array(path: str) -> ts.TensorStore:
+    """Open an existing zarr array with tensorstore, auto-detecting v2/v3."""
+    p = Path(path)
+    if (p / '.zarray').exists():
+        driver = 'zarr'
+    elif (p / 'zarr.json').exists():
+        meta = json.loads((p / 'zarr.json').read_text())
+        if meta.get('node_type', 'array') != 'array':
+            raise ValueError(f'{path} is a zarr group, not an array')
+        driver = 'zarr3'
+    else:
+        raise ValueError(f'No zarr array found at {path}')
+    return ts.open({
+        'driver': driver,
+        'kvstore': {'driver': 'file', 'path': str(p)},
+    }).result()
 
 
 def check_for_multiscale(group_path: str, container_root: str) -> Tuple[Optional[list], str]:
@@ -101,10 +118,10 @@ class ZarrRead(PyScriptObject):
         self.input_dir = HxPortFilename(self, 'inputDir', 'Input Directory')
         self.input_dir.mode = HxPortFilename.LOAD_DIRECTORY
         self.info = HxPortInfo(self, 'array_info', 'Array info')
-        self.container = None
         self.dataset = None
         self.container_path = None
         self.dataset_path = None
+        self.array_dir = None
         self.resolution = None
         self.offset = None
         self.units = None
@@ -134,22 +151,21 @@ class ZarrRead(PyScriptObject):
             if self.container_path is None:
                 hx_message.error(message='You have not selected a folder that represents a Zarr array.')
                 return
-            self.container = self.access_container(mode='r')
-            self.dataset = self.container[self.dataset_path]
-            # validate that user selected a dataset
-            if not isinstance(self.dataset, zarr.core.Array):
+            self.array_dir = self.container_path + self.dataset_path
+            if not is_zarr_array(self.array_dir):
                 hx_message.error(message='You have not selected a folder that represents a Zarr array.')
                 return
-            array_dir = self.container_path + self.dataset_path
-            parent_dir = os.path.join(self.container_path, os.path.split(self.dataset.path)[0].lstrip('/')) if self.dataset.path else self.container_path
+            self.dataset = open_ts_array(self.array_dir)
+            ndim = len(self.dataset.shape)
+            parent_dir = self.container_path if self.dataset_path == '' else str(Path(self.array_dir).parent)
             multiscales_result = check_for_multiscale(parent_dir, self.container_path)
-            self.resolution, self.offset, self.units = get_resolution_and_offset(array_dir, len(self.dataset.shape), multiscales_result)
+            self.resolution, self.offset, self.units = get_resolution_and_offset(self.array_dir, ndim, multiscales_result)
             self.update_info_box()
             for ind, dim in enumerate(self._dimensions):
                 for tb in self.slice_textboxes[dim].texts:
                     tb.clamp_range = (0, self.dataset.shape[::-1][ind])
 
-            assert len(self.dataset.shape) == 3
+            assert ndim == 3
         
         # if any of the textboxes have changed, then update the corresponding slices
         if any(s.is_new for s in self.slice_textboxes.values()):
@@ -158,16 +174,11 @@ class ZarrRead(PyScriptObject):
         pass
 
     def update_info_box(self):
-        if isinstance(self.dataset, zarr.core.Array):
-            self.info.text = '{0} array with shape {1}'.format(self.dataset.dtype, self.dataset.shape[::-1])        
+        if self.dataset is not None:
+            self.info.text = '{0} array with shape {1}'.format(
+                self.dataset.dtype.numpy_dtype, tuple(self.dataset.shape)[::-1])
         else:
             self.info.text = 'No array selected'
-
-    
-    def access_container(self, mode):       
-        store_path = zarr.NestedDirectoryStore(self.container_path)
-        container = zarr.open(store=store_path, mode=mode)
-        return container
 
     def compute(self):
         

--- a/ZarrRead.pyscro
+++ b/ZarrRead.pyscro
@@ -211,6 +211,11 @@ class ZarrRead(PyScriptObject):
         if self.ndim == 3 and ch != 0:
             hx_message.error(message='Channel index must be 0 for a 3D array.')
             return
+        if self.ndim == 4:
+            max_ch = self.dataset.shape[0] - 1
+            if ch < 0 or ch > max_ch:
+                hx_message.error(message='Channel index out of range. Choose within 0–{0}.'.format(max_ch))
+                return
         spatial_slices = tuple(self.slices[d] for d in self._dimensions)[::-1]
         if any(sl.start == sl.stop for sl in spatial_slices):
             hx_message.error(message='Start and stop limits are the same along one of the (X, Y, Z) dimensions.')

--- a/ZarrRead.pyscro
+++ b/ZarrRead.pyscro
@@ -64,7 +64,7 @@ def open_ts_array(path: str) -> ts.TensorStore:
     return ts.open({
         'driver': driver,
         'kvstore': {'driver': 'file', 'path': str(p)},
-    }).result()
+    }, write=False).result()
 
 
 def check_for_multiscale(group_path: str, container_root: str) -> Tuple[Optional[list], str]:

--- a/ZarrRead.pyscro
+++ b/ZarrRead.pyscro
@@ -61,37 +61,36 @@ def check_for_multiscale(group_path: str, container_root: str) -> Tuple[Optional
     return check_for_multiscale(str(Path(group_path).parent), container_root)
 
 
-def get_resolution_and_offset(ds: zarr.core.Array,
-                               multiscales_group: Tuple[dict, zarr.hierarchy.Group]) -> Tuple[List[float], List[float], List[str]]:
-    """checks multiscale attribute of the .zarr group
-        for voxel_size(scale), offset(translation) and units values
-    """
+def get_resolution_and_offset(array_dir: str, ndim: int,
+                               multiscales_result: Tuple) -> Tuple[List[float], List[float], List[str]]:
+    voxel_size = [1.0] * ndim
+    offset = [0.0] * ndim
+    units = ['nanometer'] * ndim
+    multiscales, ms_dir = multiscales_result
 
-    voxel_size = [1] * ds.ndim
-    offset = [0] * ds.ndim
-    units = ["nanometer"] * ds.ndim
-    multiscales = multiscales_group[0]
+    if multiscales is None:
+        print('Multiscales not found. Using defaults: Resolution={0} nm, Offset={1} nm'.format(voxel_size, offset))
+        return voxel_size, offset, units
 
-    if multiscales is not None:
-        print("Found multiscales attributes")
-        scale = os.path.split(ds.path)[1]
-        
-        if multiscales[0]["axes"]:
-            units = [item["unit"] for item in multiscales[0]["axes"]]
-        else: 
-            print("Units are not defined in multiscales. Using default: Units = {0}".format(units))
-            
-        # get s0 level voxel_size and offset
-        for level in multiscales[0]["datasets"]:
-            if level["path"].lstrip("/") == scale:
-                for attr in level["coordinateTransformations"]:
-                    if attr["type"] == "scale":
-                        voxel_size = attr["scale"]
-                    elif attr["type"] == "translation":
-                        offset = attr["translation"]
-                return voxel_size, offset, units
+    print('Found multiscales attributes')
+    try:
+        rel_path = str(Path(array_dir).relative_to(ms_dir))
+    except ValueError:
+        rel_path = os.path.basename(array_dir)
+
+    if multiscales[0].get('axes'):
+        units = [item['unit'] for item in multiscales[0]['axes']]
     else:
-        print('Multiscales attributes not found. Using default: Resolution = {0} nm, Offset = {1} nm'.format(voxel_size, offset))
+        print('Units not defined in multiscales. Using default: {0}'.format(units))
+
+    for level in multiscales[0]['datasets']:
+        if level['path'].lstrip('/') == rel_path.lstrip('/'):
+            for attr in level['coordinateTransformations']:
+                if attr['type'] == 'scale':
+                    voxel_size = attr['scale']
+                elif attr['type'] == 'translation':
+                    offset = attr['translation']
+            return voxel_size, offset, units
 
     return voxel_size, offset, units
 
@@ -141,9 +140,10 @@ class ZarrRead(PyScriptObject):
             if not isinstance(self.dataset, zarr.core.Array):
                 hx_message.error(message='You have not selected a folder that represents a Zarr array.')
                 return
+            array_dir = self.container_path + self.dataset_path
             parent_dir = os.path.join(self.container_path, os.path.split(self.dataset.path)[0].lstrip('/')) if self.dataset.path else self.container_path
             multiscales_result = check_for_multiscale(parent_dir, self.container_path)
-            self.resolution, self.offset, self.units = get_resolution_and_offset(self.dataset, multiscales_result)
+            self.resolution, self.offset, self.units = get_resolution_and_offset(array_dir, len(self.dataset.shape), multiscales_result)
             self.update_info_box()
             for ind, dim in enumerate(self._dimensions):
                 for tb in self.slice_textboxes[dim].texts:

--- a/ZarrRead.pyscro
+++ b/ZarrRead.pyscro
@@ -178,8 +178,12 @@ class ZarrRead(PyScriptObject):
                 self.channel.texts[0].clamp_range = (0, 0)
             self.update_info_box()
             for ind, dim in enumerate(self._dimensions):
+                size = self.dataset.shape[::-1][ind]
                 for tb in self.slice_textboxes[dim].texts:
-                    tb.clamp_range = (0, self.dataset.shape[::-1][ind])
+                    tb.clamp_range = (0, size)
+                self.slice_textboxes[dim].texts[0].value = 0
+                self.slice_textboxes[dim].texts[1].value = size
+                self.slices[dim] = slice(0, size)
         
         # if any of the textboxes have changed, then update the corresponding slices
         if any(s.is_new for s in self.slice_textboxes.values()):

--- a/ZarrRead.pyscro
+++ b/ZarrRead.pyscro
@@ -3,7 +3,8 @@ from pathlib import Path
 import numpy as np
 import dask.array as da
 import os
-from typing import Union, List, Tuple
+import json
+from typing import List, Tuple, Optional
 _container_extension = '.zarr'
 
 def split_path_at_container(path: str):
@@ -19,25 +20,45 @@ def split_path_at_container(path: str):
                 result[0] += parent.suffix
     return result
 
-def access_parent(node: Union[zarr.core.Array, zarr.hierarchy.Group]) -> zarr.hierarchy.Group:
-    """
-    Get the parent (zarr.Group) of an input zarr array(ds).
-    """
-    parent_path = os.path.split(node.path)[0]
-    return zarr.hierarchy.group(store=node.store, path=parent_path)
+def detect_zarr_version(path: str) -> Optional[str]:
+    p = Path(path)
+    if (p / '.zarray').exists() or (p / '.zgroup').exists():
+        return 'v2'
+    if (p / 'zarr.json').exists():
+        return 'v3'
+    return None
 
-def check_for_multiscale(group: zarr.hierarchy.Group) -> Tuple[dict, zarr.hierarchy.Group]:
-    """check if multiscale attribute exists in the input group and for any parent level group
-    """
-    multiscales = group.attrs.get("multiscales", None)
 
+def is_zarr_array(path: str) -> bool:
+    p = Path(path)
+    if (p / '.zarray').exists():
+        return True
+    if (p / 'zarr.json').exists():
+        meta = json.loads((p / 'zarr.json').read_text())
+        return meta.get('node_type', 'array') == 'array'
+    return False
+
+
+def read_attrs(path: str) -> dict:
+    """Read zarr attributes (.zattrs for v2, zarr.json["attributes"] for v3)."""
+    p = Path(path)
+    if (p / '.zattrs').exists():
+        return json.loads((p / '.zattrs').read_text())
+    if (p / 'zarr.json').exists():
+        meta = json.loads((p / 'zarr.json').read_text())
+        return meta.get('attributes', {})
+    return {}
+
+
+def check_for_multiscale(group_path: str, container_root: str) -> Tuple[Optional[list], str]:
+    """Recursively walk up the directory hierarchy searching for multiscales attribute."""
+    attrs = read_attrs(group_path)
+    multiscales = attrs.get('multiscales', None)
     if multiscales:
-        return (multiscales, group)
-
-    if group.path == "":
-        return (multiscales, group)
-
-    return check_for_multiscale(access_parent(group))
+        return (multiscales, group_path)
+    if os.path.normpath(group_path) == os.path.normpath(container_root):
+        return (None, group_path)
+    return check_for_multiscale(str(Path(group_path).parent), container_root)
 
 
 def get_resolution_and_offset(ds: zarr.core.Array,
@@ -120,7 +141,9 @@ class ZarrRead(PyScriptObject):
             if not isinstance(self.dataset, zarr.core.Array):
                 hx_message.error(message='You have not selected a folder that represents a Zarr array.')
                 return
-            self.resolution, self.offset, self.units = get_resolution_and_offset(self.dataset, check_for_multiscale(access_parent(self.dataset)))
+            parent_dir = os.path.join(self.container_path, os.path.split(self.dataset.path)[0].lstrip('/')) if self.dataset.path else self.container_path
+            multiscales_result = check_for_multiscale(parent_dir, self.container_path)
+            self.resolution, self.offset, self.units = get_resolution_and_offset(self.dataset, multiscales_result)
             self.update_info_box()
             for ind, dim in enumerate(self._dimensions):
                 for tb in self.slice_textboxes[dim].texts:

--- a/ZarrRead.pyscro
+++ b/ZarrRead.pyscro
@@ -122,27 +122,30 @@ class ZarrRead(PyScriptObject):
         self.container_path = None
         self.dataset_path = None
         self.array_dir = None
+        self.ndim = None
         self.resolution = None
         self.offset = None
         self.units = None
 
+        self.channel = HxPortIntTextN(self, 'channel', 'Channel')
+        self.channel.texts = [HxPortIntTextN.IntText(label='Index', value=0)]
 
         self._dimensions = ('x', 'y', 'z')
         self.slice_textboxes = dict()
-        self.update_info_box()        
-        
+        self.update_info_box()
+
         for dim in self._dimensions:
             dim_disp = dim.upper()
-            self.slice_textboxes[dim] = HxPortIntTextN(self, 
-                                                       label='{0} limits'.format(dim_disp), 
+            self.slice_textboxes[dim] = HxPortIntTextN(self,
+                                                       label='{0} limits'.format(dim_disp),
                                                        name='{0}_lims'.format(dim))
-                    
-            self.slice_textboxes[dim].texts = [HxPortIntTextN.IntText(label="Start", 
+
+            self.slice_textboxes[dim].texts = [HxPortIntTextN.IntText(label="Start",
                                                                       value=0),
-                                               HxPortIntTextN.IntText(label="Stop", 
+                                               HxPortIntTextN.IntText(label="Stop",
                                                                       value=0)]
-                
-        self.slices = {d: slice(0, 1) for d in self._dimensions} 
+
+        self.slices = {d: slice(0, 1) for d in self._dimensions}
     
 
     def update(self):
@@ -157,15 +160,25 @@ class ZarrRead(PyScriptObject):
                 return
             self.dataset = open_ts_array(self.array_dir)
             ndim = len(self.dataset.shape)
+            if ndim not in (3, 4):
+                hx_message.error(message='Only 3D and 4D arrays are supported (got {0}D).'.format(ndim))
+                return
+            self.ndim = ndim
             parent_dir = self.container_path if self.dataset_path == '' else str(Path(self.array_dir).parent)
             multiscales_result = check_for_multiscale(parent_dir, self.container_path)
             self.resolution, self.offset, self.units = get_resolution_and_offset(self.array_dir, ndim, multiscales_result)
+            if ndim == 4:
+                # drop the leading channel axis from spatial metadata
+                self.resolution = self.resolution[-3:]
+                self.offset = self.offset[-3:]
+                self.units = self.units[-3:]
+                self.channel.texts[0].clamp_range = (0, self.dataset.shape[0] - 1)
+            else:
+                self.channel.texts[0].clamp_range = (0, 0)
             self.update_info_box()
             for ind, dim in enumerate(self._dimensions):
                 for tb in self.slice_textboxes[dim].texts:
                     tb.clamp_range = (0, self.dataset.shape[::-1][ind])
-
-            assert ndim == 3
         
         # if any of the textboxes have changed, then update the corresponding slices
         if any(s.is_new for s in self.slice_textboxes.values()):
@@ -186,24 +199,25 @@ class ZarrRead(PyScriptObject):
             return
 
         result = hx_project.create('HxUniformScalarField3')
-        slices_ = tuple(self.slices[d] for d in self._dimensions)[::-1]
-        if any(sl.start==sl.stop for sl in slices_):
+        ch = self.channel.texts[0].value
+        if self.ndim == 3 and ch != 0:
+            hx_message.error(message='Channel index must be 0 for a 3D array.')
+            return
+        spatial_slices = tuple(self.slices[d] for d in self._dimensions)[::-1]
+        if any(sl.start == sl.stop for sl in spatial_slices):
             hx_message.error(message='Start and stop limits are the same along one of the (X, Y, Z) dimensions.')
             return
-        array = self.dataset[slices_].read().result().T
-        shape_native_res = ((s-1) * r for s, r in zip(array.shape, self.resolution[::-1]))
-        
-        # amira doesn't like numpy uint64 or uint32
+        ts_slices = (ch,) + spatial_slices if self.ndim == 4 else spatial_slices
+        array = self.dataset[ts_slices].read().result().T
+        shape_native_res = ((s - 1) * r for s, r in zip(array.shape, self.resolution[::-1]))
+
         if array.dtype in (np.dtype('uint64'), np.dtype('uint32')):
             array = array.astype('uint16')
         if array.dtype == np.dtype('int64'):
             array = array.astype('int32')
-        
-        # for a 3D array with dimensions numbered [0,1,2], amira assigns named dimensions ['x','y','z'] 
-        # so everything has to be flipped relative to the pythonic indexing scheme
-        # in amira, the bounding box defines the pixel size and position in space of the data. So we set the bounding box and origin in nanometers.
-        bbox_starts = tuple((r * s.start) + o for r, s, o in zip(self.resolution, slices_, self.offset))[::-1]
-        bbox_stops = tuple(o + s for o, s in zip(bbox_starts, shape_native_res)) 
+
+        bbox_starts = tuple((r * s.start) + o for r, s, o in zip(self.resolution, spatial_slices, self.offset))[::-1]
+        bbox_stops = tuple(o + s for o, s in zip(bbox_starts, shape_native_res))
 
         result.bounding_box = bbox_starts, bbox_stops
         result.set_array(array)

--- a/ZarrRead.pyscro
+++ b/ZarrRead.pyscro
@@ -190,7 +190,7 @@ class ZarrRead(PyScriptObject):
         if any(sl.start==sl.stop for sl in slices_):
             hx_message.error(message='Start and stop limits are the same along one of the (X, Y, Z) dimensions.')
             return
-        array = da.from_array(self.container[self.dataset_path])[slices_].compute().T
+        array = self.dataset[slices_].read().result().T
         shape_native_res = ((s-1) * r for s, r in zip(array.shape, self.resolution[::-1]))
         
         # amira doesn't like numpy uint64 or uint32

--- a/ZarrRead.pyscro
+++ b/ZarrRead.pyscro
@@ -197,6 +197,9 @@ class ZarrRead(PyScriptObject):
         
         if not self.do_it.was_hit:
             return
+        if self.dataset is None:
+            hx_message.error(message='No array selected. Please choose a Zarr array first.')
+            return
 
         result = hx_project.create('HxUniformScalarField3')
         ch = self.channel.texts[0].value

--- a/ZarrWrite.pyscro
+++ b/ZarrWrite.pyscro
@@ -6,14 +6,6 @@ from pathlib import Path
 _container_extension = '.zarr'
 
 
-def detect_zarr_version(path: str):
-    p = Path(path)
-    if (p / '.zarray').exists() or (p / '.zgroup').exists():
-        return 'v2'
-    if (p / 'zarr.json').exists():
-        return 'v3'
-    return None
-
 
 def is_zarr_array(path: str) -> bool:
     p = Path(path)
@@ -87,10 +79,13 @@ def split_path_at_container(path: str):
 
 class ZarrWrite(PyScriptObject):
     def __init__(self):
-        self.data.valid_types = ['HxUniformScalarField3']                
+        self.data.valid_types = ['HxUniformScalarField3']
         self.do_it = HxPortDoIt(self, 'write', 'Save Zarr')
         self.output_dir = HxPortFilename(self, 'outputDir', 'Output Directory')
         self.output_dir.mode = HxPortFilename.LOAD_DIRECTORY
+        self.zarr_format = HxPortComboBox(self, 'zarrFormat', 'Zarr Format')
+        self.zarr_format.entries = ['Zarr v2 (ome-ngff 0.4)', 'Zarr v3 (ome-ngff 0.5)']
+        self.zarr_format.selected_index = 1
         self.container_path = None
         self.dataset_path = None
 
@@ -113,6 +108,7 @@ class ZarrWrite(PyScriptObject):
         ds_name = self.data.source().name.strip('-')
         node_path = self.container_path + self.dataset_path
 
+        zarr_version = self.selected_zarr_version()
         if is_zarr_array(node_path):
             existing = open_ts_array(node_path)
             if tuple(existing.shape) != output.shape:
@@ -121,17 +117,18 @@ class ZarrWrite(PyScriptObject):
             print('Saving {0} to {1}'.format(ds_name, node_path))
             existing[...].write(output).result()
             parent_dir = self.container_path if self.dataset_path == '' else str(Path(node_path).parent)
-            zarr_version = detect_zarr_version(node_path) or 'v3'
             self.add_multiscales_metadata(parent_dir, os.path.basename(node_path), zarr_version)
         else:
             array_dir = os.path.join(node_path, ds_name, 's0')
             group_dir = os.path.join(node_path, ds_name)
-            zarr_version = detect_zarr_version(node_path) or 'v3'
             print('Saving {0} to {1}'.format(ds_name, array_dir))
             ensure_group_metadata(node_path, zarr_version)
             ensure_group_metadata(group_dir, zarr_version)
             create_ts_array(array_dir, output, zarr_version)
             self.add_multiscales_metadata(group_dir, 's0', zarr_version)
+
+    def selected_zarr_version(self) -> str:
+        return 'v2' if self.zarr_format.selected_index == 0 else 'v3'
 
     def bbox_to_slices(self):
         # convert the bounding box of the input data (real units) to a tuple of slices (indices)

--- a/ZarrWrite.pyscro
+++ b/ZarrWrite.pyscro
@@ -87,7 +87,7 @@ class ZarrWrite(PyScriptObject):
         self.zarr_format.name = 'zarrFormat'
         self.zarr_format.label = 'Zarr Format'
         _fmt_menu = HxPortButtonMenu.Menu(options=['Zarr v2', 'Zarr v3'])
-        _fmt_menu.selected_index = 1
+        _fmt_menu.selected = 1
         self.zarr_format.menus = [_fmt_menu]
         self.container_path = None
         self.dataset_path = None
@@ -131,7 +131,7 @@ class ZarrWrite(PyScriptObject):
             self.add_multiscales_metadata(group_dir, 's0', zarr_version)
 
     def selected_zarr_version(self) -> str:
-        return 'v2' if self.zarr_format.menus[0].selected_index == 0 else 'v3'
+        return 'v2' if self.zarr_format.menus[0].selected == 0 else 'v3'
 
     def bbox_to_slices(self):
         # convert the bounding box of the input data (real units) to a tuple of slices (indices)

--- a/ZarrWrite.pyscro
+++ b/ZarrWrite.pyscro
@@ -83,7 +83,7 @@ class ZarrWrite(PyScriptObject):
         self.do_it = HxPortDoIt(self, 'write', 'Save Zarr')
         self.output_dir = HxPortFilename(self, 'outputDir', 'Output Directory')
         self.output_dir.mode = HxPortFilename.LOAD_DIRECTORY
-        self.zarr_format = HxPortMultiMenu(self, 'zarrFormat', 'Zarr Format', 1)
+        self.zarr_format = HxPortMultiMenu(self, 'zarrFormat', 'Zarr Format')
         self.zarr_format.menus[0].entries = ['Zarr v2 (ome-ngff 0.4)', 'Zarr v3 (ome-ngff 0.5)']
         self.zarr_format.menus[0].selected_index = 1
         self.container_path = None

--- a/ZarrWrite.pyscro
+++ b/ZarrWrite.pyscro
@@ -83,9 +83,12 @@ class ZarrWrite(PyScriptObject):
         self.do_it = HxPortDoIt(self, 'write', 'Save Zarr')
         self.output_dir = HxPortFilename(self, 'outputDir', 'Output Directory')
         self.output_dir.mode = HxPortFilename.LOAD_DIRECTORY
-        self.zarr_format = HxPortMultiMenu(self, 'zarrFormat', 'Zarr Format')
-        self.zarr_format.menus[0].entries = ['Zarr v2 (ome-ngff 0.4)', 'Zarr v3 (ome-ngff 0.5)']
-        self.zarr_format.menus[0].selected_index = 1
+        self.zarr_format = HxPortMultiMenu(self)
+        self.zarr_format.name = 'zarrFormat'
+        self.zarr_format.label = 'Zarr Format'
+        _fmt_menu = HxPortButtonMenu.Menu(options=['Zarr v2', 'Zarr v3'])
+        _fmt_menu.selected_index = 1
+        self.zarr_format.menus = [_fmt_menu]
         self.container_path = None
         self.dataset_path = None
 

--- a/ZarrWrite.pyscro
+++ b/ZarrWrite.pyscro
@@ -84,11 +84,12 @@ class ZarrWrite(PyScriptObject):
         self.output_dir = HxPortFilename(self, 'outputDir', 'Output Directory')
         self.output_dir.mode = HxPortFilename.LOAD_DIRECTORY
         self.zarr_format = HxPortMultiMenu(self)
+        self.zarr_format.menus = [
+            HxPortButtonMenu.Menu(options=['Zarr v2', 'Zarr v3']),
+        ]
         self.zarr_format.name = 'zarrFormat'
         self.zarr_format.label = 'Zarr Format'
-        _fmt_menu = HxPortButtonMenu.Menu(options=['Zarr v2', 'Zarr v3'])
-        _fmt_menu.selected = 1
-        self.zarr_format.menus = [_fmt_menu]
+        self.zarr_format.position = 1
         self.container_path = None
         self.dataset_path = None
 

--- a/ZarrWrite.pyscro
+++ b/ZarrWrite.pyscro
@@ -107,32 +107,31 @@ class ZarrWrite(PyScriptObject):
         if not self.do_it.was_hit:
             return
         if self.data.source() is None:
-            return    
-        # Slices and array have to be transposed b/c amira uses x,y,z axis ordering but we use z,y,x for 
-        # zarr
-        self.slices = self.bbox_to_slices()
+            return
+
         output = self.data.source().get_array().T
         ds_name = self.data.source().name.strip('-')
+        node_path = self.container_path + self.dataset_path
 
-        if isinstance(self.dataset, zarr.Group):   
-            print('Saving {0} to {1}'.format(ds_name, self.dataset.name))     
-            self.dataset[f'{ds_name}/s0'] = output
-            ds_name = self.data.source().name.strip('-')
-            self.add_multiscales_metadata(self.dataset[ds_name], 's0')
-            print("Added voxel size and offset attributes")
-            print('Save complete')
-            
-        elif isinstance(self.dataset, zarr.Array):
-            if self.dataset.shape==output.shape:
-                print('Preparing to save {0} to {1}'.format( self.data.source().name.strip('-'), self.dataset))
-                parent_group = self.access_parent(self.dataset)
-                ds_name = os.path.split(self.dataset.name)[-1]
-                zarr.save_array(store=self.dataset.store, path=self.dataset.path, arr=output)
-                self.add_multiscales_metadata(parent_group,  ds_name)
-                print("Added voxel size and offset attributes")
-                print('Save complete')
-            else:
-                hx_message.error(message="You're trying to store the amira array in the dataset with different dimensions")
+        if is_zarr_array(node_path):
+            existing = open_ts_array(node_path)
+            if tuple(existing.shape) != output.shape:
+                hx_message.error(message='Array dimensions do not match the target dataset.')
+                return
+            print('Saving {0} to {1}'.format(ds_name, node_path))
+            existing[...].write(output).result()
+            parent_dir = self.container_path if self.dataset_path == '' else str(Path(node_path).parent)
+            zarr_version = detect_zarr_version(node_path) or 'v3'
+            self.add_multiscales_metadata(parent_dir, os.path.basename(node_path), zarr_version)
+        else:
+            array_dir = os.path.join(node_path, ds_name, 's0')
+            group_dir = os.path.join(node_path, ds_name)
+            zarr_version = detect_zarr_version(node_path) or 'v3'
+            print('Saving {0} to {1}'.format(ds_name, array_dir))
+            ensure_group_metadata(node_path, zarr_version)
+            ensure_group_metadata(group_dir, zarr_version)
+            create_ts_array(array_dir, output, zarr_version)
+            self.add_multiscales_metadata(group_dir, 's0', zarr_version)
 
     def bbox_to_slices(self):
         # convert the bounding box of the input data (real units) to a tuple of slices (indices)

--- a/ZarrWrite.pyscro
+++ b/ZarrWrite.pyscro
@@ -154,34 +154,40 @@ class ZarrWrite(PyScriptObject):
         else:
             return self.if_name_exists(path, zarr_name, copy_num+1)
     
-    def add_multiscales_metadata(self, z_group, ds_name):
-        # default order - z, y, x
+    def add_multiscales_metadata(self, group_dir: str, ds_name: str, zarr_version: str):
         axes = ['z', 'y', 'x']
-        #default units - nm
         unit = 'nanometer'
-        # offset values, z, y, x order
         offset = self.data.source().ports.PhysicalSize.text.split('from')[1].strip().split(', ')[::-1]
-        # voxel size, z, y, x order
-        voxel_size = self.data.source().ports.VoxelSize.text.split(" x ")[::-1]        
-        z_attrs: dict = {"multiscales": [{}]}
-        z_attrs["multiscales"][0]["axes"] = [
-            {"name": axis, "type": "space", "unit": unit} for axis in axes
+        voxel_size = self.data.source().ports.VoxelSize.text.split(' x ')[::-1]
+
+        version_str = '0.5' if zarr_version == 'v3' else '0.4'
+        attrs: dict = {'multiscales': [{}]}
+        attrs['multiscales'][0]['axes'] = [
+            {'name': axis, 'type': 'space', 'unit': unit} for axis in axes
         ]
-        z_attrs["multiscales"][0]["coordinateTransformations"] = [
-            {"scale": [1.0, 1.0, 1.0], "type": "scale"}
+        attrs['multiscales'][0]['coordinateTransformations'] = [
+            {'scale': [1.0, 1.0, 1.0], 'type': 'scale'}
         ]
-        z_attrs["multiscales"][0]["datasets"] = [
+        attrs['multiscales'][0]['datasets'] = [
             {
-                "coordinateTransformations": [
-                    {"scale": [float(i) for i in voxel_size], "type": "scale"},
-                    {"translation": [float(i) for i in offset], "type": "translation"},
+                'coordinateTransformations': [
+                    {'scale': [float(i) for i in voxel_size], 'type': 'scale'},
+                    {'translation': [float(i) for i in offset], 'type': 'translation'},
                 ],
-                "path": ds_name,
+                'path': ds_name,
             }
         ]
+        attrs['multiscales'][0]['name'] = ''
+        attrs['multiscales'][0]['version'] = version_str
 
-        z_attrs["multiscales"][0]["name"] = ""
-        z_attrs["multiscales"][0]["version"] = "0.4"
-
-       
-        z_group.attrs.update(z_attrs)
+        p = Path(group_dir)
+        if zarr_version == 'v3':
+            zarr_json_path = p / 'zarr.json'
+            if zarr_json_path.exists():
+                meta = json.loads(zarr_json_path.read_text())
+            else:
+                meta = {'zarr_format': 3, 'node_type': 'group'}
+            meta['attributes'] = attrs
+            zarr_json_path.write_text(json.dumps(meta, indent=2))
+        else:
+            (p / '.zattrs').write_text(json.dumps(attrs, indent=2))

--- a/ZarrWrite.pyscro
+++ b/ZarrWrite.pyscro
@@ -37,14 +37,34 @@ def open_ts_array(path: str) -> ts.TensorStore:
 
 def create_ts_array(path: str, data: np.ndarray, zarr_version: str = 'v3') -> ts.TensorStore:
     """Create a new zarr array and write data into it."""
-    driver = 'zarr3' if zarr_version == 'v3' else 'zarr'
     Path(path).mkdir(parents=True, exist_ok=True)
-    store = ts.open({
-        'driver': driver,
-        'kvstore': {'driver': 'file', 'path': str(path)},
-        'create': True,
-        'open': True,
-    }, shape=list(data.shape), dtype=data.dtype).result()
+    if zarr_version == 'v3':
+        spec = {
+            'driver': 'zarr3',
+            'kvstore': {'driver': 'file', 'path': str(path)},
+            'create': True,
+            'open': True,
+            'metadata': {
+                'chunk_grid': {'name': 'regular', 'configuration': {'chunk_shape': [128, 128, 128]}},
+                'codecs': [
+                    {'name': 'bytes'},
+                    {'name': 'zstd', 'configuration': {'level': 3}},
+                ],
+            },
+        }
+    else:
+        spec = {
+            'driver': 'zarr',
+            'kvstore': {'driver': 'file', 'path': str(path)},
+            'create': True,
+            'open': True,
+            'metadata': {
+                'chunks': [128, 128, 128],
+                'compressor': {'id': 'zstd', 'level': 3},
+                'dimension_separator': '/',
+            },
+        }
+    store = ts.open(spec, shape=list(data.shape), dtype=data.dtype).result()
     store[...].write(data).result()
     return store
 

--- a/ZarrWrite.pyscro
+++ b/ZarrWrite.pyscro
@@ -1,7 +1,75 @@
-import zarr
-from pathlib import Path
+import tensorstore as ts
+import json
+import numpy as np
 import os
+from pathlib import Path
 _container_extension = '.zarr'
+
+
+def detect_zarr_version(path: str):
+    p = Path(path)
+    if (p / '.zarray').exists() or (p / '.zgroup').exists():
+        return 'v2'
+    if (p / 'zarr.json').exists():
+        return 'v3'
+    return None
+
+
+def is_zarr_array(path: str) -> bool:
+    p = Path(path)
+    if (p / '.zarray').exists():
+        return True
+    if (p / 'zarr.json').exists():
+        meta = json.loads((p / 'zarr.json').read_text())
+        return meta.get('node_type', 'array') == 'array'
+    return False
+
+
+def open_ts_array(path: str) -> ts.TensorStore:
+    """Open an existing zarr array with tensorstore, auto-detecting v2/v3."""
+    p = Path(path)
+    if (p / '.zarray').exists():
+        driver = 'zarr'
+    elif (p / 'zarr.json').exists():
+        meta = json.loads((p / 'zarr.json').read_text())
+        if meta.get('node_type', 'array') != 'array':
+            raise ValueError(f'{path} is a zarr group, not an array')
+        driver = 'zarr3'
+    else:
+        raise ValueError(f'No zarr array found at {path}')
+    return ts.open({
+        'driver': driver,
+        'kvstore': {'driver': 'file', 'path': str(p)},
+    }).result()
+
+
+def create_ts_array(path: str, data: np.ndarray, zarr_version: str = 'v3') -> ts.TensorStore:
+    """Create a new zarr array and write data into it."""
+    driver = 'zarr3' if zarr_version == 'v3' else 'zarr'
+    Path(path).mkdir(parents=True, exist_ok=True)
+    store = ts.open({
+        'driver': driver,
+        'kvstore': {'driver': 'file', 'path': str(path)},
+        'create': True,
+        'open': True,
+    }, shape=list(data.shape), dtype=data.dtype).result()
+    store[...].write(data).result()
+    return store
+
+
+def ensure_group_metadata(path: str, zarr_version: str = 'v3'):
+    """Create group metadata file if the directory lacks it."""
+    p = Path(path)
+    p.mkdir(parents=True, exist_ok=True)
+    if zarr_version == 'v3':
+        zarr_json = p / 'zarr.json'
+        if not zarr_json.exists():
+            zarr_json.write_text(json.dumps(
+                {'zarr_format': 3, 'node_type': 'group', 'attributes': {}}, indent=2))
+    else:
+        zgroup = p / '.zgroup'
+        if not zgroup.exists():
+            zgroup.write_text(json.dumps({'zarr_format': 2}))
 
 def split_path_at_container(path: str):
     # check whether a path contains a valid file path to a container file, and if so which container format it is
@@ -23,29 +91,17 @@ class ZarrWrite(PyScriptObject):
         self.do_it = HxPortDoIt(self, 'write', 'Save Zarr')
         self.output_dir = HxPortFilename(self, 'outputDir', 'Output Directory')
         self.output_dir.mode = HxPortFilename.LOAD_DIRECTORY
-        self.container = None
-        self.dataset = None
         self.container_path = None
-        self.dataset_path = None        
-        self.slices = None
+        self.dataset_path = None
 
     def update(self):
         if self.output_dir.is_new and self.output_dir.filenames is not None:
-            if ".zarr" in self.output_dir.filenames:
+            if '.zarr' in self.output_dir.filenames:
                 self.container_path, self.dataset_path = split_path_at_container(self.output_dir.filenames)
             else:
                 dir_path = self.output_dir.filenames
-                container_name = 'amira_export'
-                self.container_path = self.if_name_exists(dir_path, container_name, 0)
+                self.container_path = self.if_name_exists(dir_path, 'amira_export', 0)
                 self.dataset_path = ''
-            self.container = self.access_container(mode='a')
-            self.dataset = self.container[self.dataset_path]
-        pass
-
-    def access_container(self, mode):       
-        z_store = zarr.NestedDirectoryStore(self.container_path)
-        container = zarr.open(store=z_store, mode=mode)
-        return container
 
     def compute(self):
         if not self.do_it.was_hit:
@@ -89,22 +145,6 @@ class ZarrWrite(PyScriptObject):
         return slices
     
 
-    def separate_store_path(self, store, path):
-   
-        new_store, path_prefix = os.path.split(store)
-        if ".zarr" in path_prefix or ".n5" in path_prefix:
-            return store, path
-        return self.separate_store_path(new_store, os.path.join(path_prefix, path).replace("\\","/"))
-
-    def access_parent(self, node):
-        store_path, node_path = self.separate_store_path(node.store.path, node.path)
-        if node_path == "":
-            raise RuntimeError(
-                f"{node.name} is in the root group of the {node.store.path} store."
-            )
-        else:
-            return zarr.open(store=store_path, path=os.path.split(node_path)[0], mode="a")
-        
     def if_name_exists(self, path, zarr_name, copy_num):
         if copy_num == 0:
             zarr_path=os.path.join(path, f"{zarr_name}.zarr").replace("\\","/")

--- a/ZarrWrite.pyscro
+++ b/ZarrWrite.pyscro
@@ -83,9 +83,9 @@ class ZarrWrite(PyScriptObject):
         self.do_it = HxPortDoIt(self, 'write', 'Save Zarr')
         self.output_dir = HxPortFilename(self, 'outputDir', 'Output Directory')
         self.output_dir.mode = HxPortFilename.LOAD_DIRECTORY
-        self.zarr_format = HxPortComboBox(self, 'zarrFormat', 'Zarr Format')
-        self.zarr_format.entries = ['Zarr v2 (ome-ngff 0.4)', 'Zarr v3 (ome-ngff 0.5)']
-        self.zarr_format.selected_index = 1
+        self.zarr_format = HxPortMultiMenu(self, 'zarrFormat', 'Zarr Format', 1)
+        self.zarr_format.menus[0].entries = ['Zarr v2 (ome-ngff 0.4)', 'Zarr v3 (ome-ngff 0.5)']
+        self.zarr_format.menus[0].selected_index = 1
         self.container_path = None
         self.dataset_path = None
 
@@ -128,7 +128,7 @@ class ZarrWrite(PyScriptObject):
             self.add_multiscales_metadata(group_dir, 's0', zarr_version)
 
     def selected_zarr_version(self) -> str:
-        return 'v2' if self.zarr_format.selected_index == 0 else 'v3'
+        return 'v2' if self.zarr_format.menus[0].selected_index == 0 else 'v3'
 
     def bbox_to_slices(self):
         # convert the bounding box of the input data (real units) to a tuple of slices (indices)


### PR DESCRIPTION
## Summary

Rewrites `ZarrRead` and `ZarrWrite` to use [TensorStore](https://google.github.io/tensorstore/) instead of `zarr` + `dask.array`, adding Zarr v2/v3 auto-detection, 4D array support, and improved UX across both modules.

### ZarrRead

- Replaces `zarr`/`dask` with `tensorstore` for reading; arrays are opened read-only
- Auto-detects Zarr v2 (`.zarray`) and v3 (`zarr.json`) on open
- Adds a **Channel** port for selecting a single channel from 4D (C, Z, Y, X) arrays; channel index is validated immediately in `update()` with a helpful error message
- X/Y/Z slice limit text boxes are now pre-populated from the array shape when a dataset is selected
- `get_resolution_and_offset` now traverses the filesystem directly rather than through zarr group objects; handles axes that lack a `unit` field (e.g. channel axes)
- Guards `compute()` against being called without a valid dataset selection

### ZarrWrite

- Replaces `zarr` with `tensorstore` for writing
- Adds a **Zarr Format** dropdown (v2 / v3) to the GUI
- New arrays are written with zstd level-3 compression, 128³ chunks, and `'/'` dimension separator (v2) or the equivalent zarr3 codec spec (v3)
- `add_multiscales_metadata` now writes JSON files directly (`.zattrs` for v2, `zarr.json["attributes"]` for v3) instead of relying on the zarr attributes API; sets `version` to `"0.4"` (v2) or `"0.5"` (v3)
- Removes now-unused helpers: `access_container`, `access_parent`, `separate_store_path`

### Dependency changes

- Removes: `zarr`, `dask`
- Adds: `tensorstore`
