### PR TITLE
ome-zarr support with ome-zarr-models

### DIFF
--- a/ZarrRead.pyscro
+++ b/ZarrRead.pyscro
@@ -249,6 +249,6 @@ class ZarrRead(PyScriptObject):
 
         result.bounding_box = bbox_starts, bbox_stops
         result.set_array(array)
-        result.parameters.setValue("units", self.units[0] if self.units else 'nanometer')
+        result.parameters['units'] = self.units[0] if self.units else 'nanometer'
         result.name = self.dataset_path
         result.ports.master.connect(hx_project.get(self.name))

--- a/ZarrRead.pyscro
+++ b/ZarrRead.pyscro
@@ -2,8 +2,8 @@ import tensorstore as ts
 from pathlib import Path
 import numpy as np
 import os
-import json
 import zarr
+from ome_zarr_models import open_ome_zarr
 from typing import List, Tuple, Optional
 _container_extension = '.zarr'
 
@@ -43,19 +43,31 @@ def open_ts_array(path: str) -> ts.TensorStore:
     }, write=False).result()
 
 
-def check_for_multiscale(group_path: str, container_root: str) -> Tuple[Optional[list], str]:
-    """Recursively walk up the directory hierarchy searching for multiscales attribute."""
-    attrs = read_attrs(group_path)
-    version = detect_zarr_version(group_path)
-    if version == 'v3':
-        multiscales = attrs.get('ome', {}).get('multiscales')
-    else:
-        multiscales = attrs.get('multiscales')
-    if multiscales:
-        return (multiscales, group_path)
-    if os.path.normpath(group_path) == os.path.normpath(container_root):
-        return (None, group_path)
-    return check_for_multiscale(str(Path(group_path).parent), container_root)
+def find_ome_image(group_path: str, container_root: str) -> Tuple:
+    """Walk up from group_path to container_root, return first valid OME-Zarr Image found."""
+    path = group_path
+    while True:
+        try:
+            grp = zarr.open_group(str(path), mode='r')
+            image = open_ome_zarr(grp)
+            return image, path
+        except Exception:
+            pass
+        if os.path.normpath(path) == os.path.normpath(container_root):
+            return None, path
+        path = str(Path(path).parent)
+
+
+def get_axes(image) -> Optional[list]:
+    """Extract axes list from an OME-Zarr Image (handles v04 and v05 attribute layout)."""
+    try:
+        return image.ome_attributes.multiscales[0].axes
+    except AttributeError:
+        pass
+    try:
+        return image.ome_attributes.ome.multiscales[0].axes
+    except AttributeError:
+        return None
 
 
 def get_resolution_and_offset(array_dir: str, ndim: int,

--- a/ZarrRead.pyscro
+++ b/ZarrRead.pyscro
@@ -50,19 +50,16 @@ def read_attrs(path: str) -> dict:
 
 def open_ts_array(path: str) -> ts.TensorStore:
     """Open an existing zarr array with tensorstore, auto-detecting v2/v3."""
-    p = Path(path)
-    if (p / '.zarray').exists():
-        driver = 'zarr'
-    elif (p / 'zarr.json').exists():
-        meta = json.loads((p / 'zarr.json').read_text())
-        if meta.get('node_type', 'array') != 'array':
+    try:
+        node = zarr.open(str(path), mode='r')
+        if not isinstance(node, zarr.Array):
             raise ValueError(f'{path} is a zarr group, not an array')
-        driver = 'zarr3'
-    else:
-        raise ValueError(f'No zarr array found at {path}')
+        driver = 'zarr3' if node.metadata.zarr_format == 3 else 'zarr'
+    except Exception as e:
+        raise ValueError(f'No zarr array found at {path}') from e
     return ts.open({
         'driver': driver,
-        'kvstore': {'driver': 'file', 'path': str(p)},
+        'kvstore': {'driver': 'file', 'path': str(path)},
     }, write=False).result()
 
 

--- a/ZarrRead.pyscro
+++ b/ZarrRead.pyscro
@@ -3,6 +3,7 @@ from pathlib import Path
 import numpy as np
 import os
 import json
+import zarr
 from typing import List, Tuple, Optional
 _container_extension = '.zarr'
 
@@ -29,13 +30,11 @@ def detect_zarr_version(path: str) -> Optional[str]:
 
 
 def is_zarr_array(path: str) -> bool:
-    p = Path(path)
-    if (p / '.zarray').exists():
-        return True
-    if (p / 'zarr.json').exists():
-        meta = json.loads((p / 'zarr.json').read_text())
-        return meta.get('node_type', 'array') == 'array'
-    return False
+    try:
+        node = zarr.open(str(path), mode='r')
+        return isinstance(node, zarr.Array)
+    except Exception:
+        return False
 
 
 def read_attrs(path: str) -> dict:

--- a/ZarrRead.pyscro
+++ b/ZarrRead.pyscro
@@ -20,32 +20,12 @@ def split_path_at_container(path: str):
                 result[0] += parent.suffix
     return result
 
-def detect_zarr_version(path: str) -> Optional[str]:
-    p = Path(path)
-    if (p / '.zarray').exists() or (p / '.zgroup').exists():
-        return 'v2'
-    if (p / 'zarr.json').exists():
-        return 'v3'
-    return None
-
-
 def is_zarr_array(path: str) -> bool:
     try:
         node = zarr.open(str(path), mode='r')
         return isinstance(node, zarr.Array)
     except Exception:
         return False
-
-
-def read_attrs(path: str) -> dict:
-    """Read zarr attributes (.zattrs for v2, zarr.json["attributes"] for v3)."""
-    p = Path(path)
-    if (p / '.zattrs').exists():
-        return json.loads((p / '.zattrs').read_text())
-    if (p / 'zarr.json').exists():
-        meta = json.loads((p / 'zarr.json').read_text())
-        return meta.get('attributes', {})
-    return {}
 
 
 def open_ts_array(path: str) -> ts.TensorStore:

--- a/ZarrRead.pyscro
+++ b/ZarrRead.pyscro
@@ -249,6 +249,6 @@ class ZarrRead(PyScriptObject):
 
         result.bounding_box = bbox_starts, bbox_stops
         result.set_array(array)
+        result.parameters.setValue("units", self.units[0] if self.units else 'nanometer')
         result.name = self.dataset_path
-        # connect the resulting 3D data to the zarr loader object
         result.ports.master.connect(hx_project.get(self.name))

--- a/ZarrRead.pyscro
+++ b/ZarrRead.pyscro
@@ -112,6 +112,7 @@ class ZarrRead(PyScriptObject):
         self.input_dir = HxPortFilename(self, 'inputDir', 'Input Directory')
         self.input_dir.mode = HxPortFilename.LOAD_DIRECTORY
         self.info = HxPortInfo(self, 'array_info', 'Array info')
+        self.units_info = HxPortInfo(self, 'units_info', 'Units')
         self.dataset = None
         self.container_path = None
         self.dataset_path = None
@@ -162,12 +163,14 @@ class ZarrRead(PyScriptObject):
             parent_dir = self.container_path if self.dataset_path == '' else str(Path(self.array_dir).parent)
             ome_result = find_ome_image(parent_dir, self.container_path)
             self.resolution, self.offset, self.units = get_resolution_and_offset(self.array_dir, ndim, ome_result)
+            display_units = list(self.units)
             if ndim == 4:
                 self.resolution = self.resolution[-3:]
                 self.offset = self.offset[-3:]
                 self.units = self.units[-3:]
             else:
                 self.channel.texts[0].clamp_range = (0, 0)
+            self.units_info.text = str(display_units)
 
             image, _ = ome_result
             axes = get_axes(image) if image is not None else None

--- a/ZarrRead.pyscro
+++ b/ZarrRead.pyscro
@@ -160,20 +160,23 @@ class ZarrRead(PyScriptObject):
                 return
             self.ndim = ndim
             parent_dir = self.container_path if self.dataset_path == '' else str(Path(self.array_dir).parent)
-            multiscales_result = check_for_multiscale(parent_dir, self.container_path)
-            self.resolution, self.offset, self.units = get_resolution_and_offset(self.array_dir, ndim, multiscales_result)
+            ome_result = find_ome_image(parent_dir, self.container_path)
+            self.resolution, self.offset, self.units = get_resolution_and_offset(self.array_dir, ndim, ome_result)
             if ndim == 4:
                 self.resolution = self.resolution[-3:]
                 self.offset = self.offset[-3:]
                 self.units = self.units[-3:]
             else:
                 self.channel.texts[0].clamp_range = (0, 0)
-            multiscales, _ = multiscales_result
-            if multiscales and multiscales[0].get('axes'):
-                all_axes = [ax['name'] for ax in multiscales[0]['axes']]
-                self._storage_axes = [ax for ax in all_axes if ax in ('x', 'y', 'z')]
+
+            image, _ = ome_result
+            axes = get_axes(image) if image is not None else None
+            if axes:
+                all_names = [ax.name for ax in axes]
+                self._storage_axes = [n for n in all_names if n in ('x', 'y', 'z')]
             else:
                 self._storage_axes = ['z', 'y', 'x']
+
             self.update_info_box()
             for dim in self._dimensions:
                 size = self.dataset.shape[-3:][self._storage_axes.index(dim)]

--- a/ZarrRead.pyscro
+++ b/ZarrRead.pyscro
@@ -71,35 +71,36 @@ def get_axes(image) -> Optional[list]:
 
 
 def get_resolution_and_offset(array_dir: str, ndim: int,
-                               multiscales_result: Tuple) -> Tuple[List[float], List[float], List[str]]:
+                               ome_result: Tuple) -> Tuple[List[float], List[float], List[str]]:
     voxel_size = [1.0] * ndim
     offset = [0.0] * ndim
     units = ['nanometer'] * ndim
-    multiscales, ms_dir = multiscales_result
+    image, ms_dir = ome_result
 
-    if multiscales is None:
+    if image is None:
         print('Multiscales not found. Using defaults: Resolution={0} nm, Offset={1} nm'.format(voxel_size, offset))
         return voxel_size, offset, units
 
     print('Found multiscales attributes')
+
     try:
         rel_path = str(Path(array_dir).relative_to(ms_dir))
     except ValueError:
         rel_path = os.path.basename(array_dir)
 
-    if multiscales[0].get('axes'):
-        units = [item.get('unit', '' if item.get('type') == 'channel' else 'nanometer')
-                 for item in multiscales[0]['axes']]
+    axes = get_axes(image)
+    if axes:
+        units = [ax.unit or ('' if ax.type == 'channel' else 'nanometer') for ax in axes]
     else:
         print('Units not defined in multiscales. Using default: {0}'.format(units))
 
-    for level in multiscales[0]['datasets']:
-        if level['path'].lstrip('/') == rel_path.lstrip('/'):
-            for attr in level['coordinateTransformations']:
-                if attr['type'] == 'scale':
-                    voxel_size = attr['scale']
-                elif attr['type'] == 'translation':
-                    offset = attr['translation']
+    for ds in image.datasets[0]:
+        if ds.path.lstrip('/') == rel_path.lstrip('/'):
+            for ct in ds.coordinateTransformations:
+                if hasattr(ct, 'scale'):
+                    voxel_size = list(ct.scale)
+                elif hasattr(ct, 'translation'):
+                    offset = list(ct.translation)
             return voxel_size, offset, units
 
     return voxel_size, offset, units

--- a/ZarrWrite.pyscro
+++ b/ZarrWrite.pyscro
@@ -170,7 +170,11 @@ class ZarrWrite(PyScriptObject):
     
     def add_multiscales_metadata(self, group_dir: str, ds_name: str, zarr_version: str):
         axes = ['z', 'y', 'x']
-        unit = 'nanometer'
+        try:
+            unit = self.data.source().parameters.getValue("units") or 'nanometer'
+        except Exception:
+            hx_message.error(message='Could not read units from field parameters. Defaulting to nanometer.')
+            unit = 'nanometer'
         offset = self.data.source().ports.PhysicalSize.text.split('from')[1].strip().split(', ')[::-1]
         voxel_size = self.data.source().ports.VoxelSize.text.split(' x ')[::-1]
         voxel_size_f = [float(v) for v in voxel_size]

--- a/ZarrWrite.pyscro
+++ b/ZarrWrite.pyscro
@@ -18,19 +18,16 @@ def is_zarr_array(path: str) -> bool:
 
 def open_ts_array(path: str) -> ts.TensorStore:
     """Open an existing zarr array with tensorstore, auto-detecting v2/v3."""
-    p = Path(path)
-    if (p / '.zarray').exists():
-        driver = 'zarr'
-    elif (p / 'zarr.json').exists():
-        meta = json.loads((p / 'zarr.json').read_text())
-        if meta.get('node_type', 'array') != 'array':
+    try:
+        node = zarr.open(str(path), mode='r')
+        if not isinstance(node, zarr.Array):
             raise ValueError(f'{path} is a zarr group, not an array')
-        driver = 'zarr3'
-    else:
-        raise ValueError(f'No zarr array found at {path}')
+        driver = 'zarr3' if node.metadata.zarr_format == 3 else 'zarr'
+    except Exception as e:
+        raise ValueError(f'No zarr array found at {path}') from e
     return ts.open({
         'driver': driver,
-        'kvstore': {'driver': 'file', 'path': str(p)},
+        'kvstore': {'driver': 'file', 'path': str(path)},
     }).result()
 
 

--- a/ZarrWrite.pyscro
+++ b/ZarrWrite.pyscro
@@ -66,18 +66,9 @@ def create_ts_array(path: str, data: np.ndarray, zarr_version: str = 'v3') -> ts
 
 
 def ensure_group_metadata(path: str, zarr_version: str = 'v3'):
-    """Create group metadata file if the directory lacks it."""
-    p = Path(path)
-    p.mkdir(parents=True, exist_ok=True)
-    if zarr_version == 'v3':
-        zarr_json = p / 'zarr.json'
-        if not zarr_json.exists():
-            zarr_json.write_text(json.dumps(
-                {'zarr_format': 3, 'node_type': 'group', 'attributes': {}}, indent=2))
-    else:
-        zgroup = p / '.zgroup'
-        if not zgroup.exists():
-            zgroup.write_text(json.dumps({'zarr_format': 2}))
+    """Create zarr group if the directory lacks it."""
+    fmt = 3 if zarr_version == 'v3' else 2
+    zarr.open_group(str(path), mode='a', zarr_format=fmt)
 
 def split_path_at_container(path: str):
     # check whether a path contains a valid file path to a container file, and if so which container format it is

--- a/ZarrWrite.pyscro
+++ b/ZarrWrite.pyscro
@@ -2,19 +2,18 @@ import tensorstore as ts
 import json
 import numpy as np
 import os
+import zarr
 from pathlib import Path
 _container_extension = '.zarr'
 
 
 
 def is_zarr_array(path: str) -> bool:
-    p = Path(path)
-    if (p / '.zarray').exists():
-        return True
-    if (p / 'zarr.json').exists():
-        meta = json.loads((p / 'zarr.json').read_text())
-        return meta.get('node_type', 'array') == 'array'
-    return False
+    try:
+        node = zarr.open(str(path), mode='r')
+        return isinstance(node, zarr.Array)
+    except Exception:
+        return False
 
 
 def open_ts_array(path: str) -> ts.TensorStore:

--- a/ZarrWrite.pyscro
+++ b/ZarrWrite.pyscro
@@ -171,7 +171,7 @@ class ZarrWrite(PyScriptObject):
     def add_multiscales_metadata(self, group_dir: str, ds_name: str, zarr_version: str):
         axes = ['z', 'y', 'x']
         try:
-            unit = self.data.source().parameters.getValue("units") or 'nanometer'
+            unit = self.data.source().parameters['units'] or 'nanometer'
         except Exception:
             hx_message.error(message='Could not read units from field parameters. Defaulting to nanometer.')
             unit = 'nanometer'

--- a/ZarrWrite.pyscro
+++ b/ZarrWrite.pyscro
@@ -1,5 +1,4 @@
 import tensorstore as ts
-import json
 import numpy as np
 import os
 import zarr
@@ -177,33 +176,25 @@ class ZarrWrite(PyScriptObject):
         voxel_size_f = [float(v) for v in voxel_size]
         translation = [float(o) for o in offset]
 
-        attrs: dict = {'multiscales': [{}]}
-        attrs['multiscales'][0]['axes'] = [
-            {'name': axis, 'type': 'space', 'unit': unit} for axis in axes
-        ]
-        attrs['multiscales'][0]['coordinateTransformations'] = [
-            {'scale': [1.0, 1.0, 1.0], 'type': 'scale'}
-        ]
-        attrs['multiscales'][0]['datasets'] = [
-            {
-                'coordinateTransformations': [
-                    {'scale': voxel_size_f, 'type': 'scale'},
-                    {'translation': translation, 'type': 'translation'},
-                ],
-                'path': ds_name,
-            }
-        ]
-        attrs['multiscales'][0]['name'] = 'amira_export'
+        multiscales_entry = {
+            'axes': [{'name': axis, 'type': 'space', 'unit': unit} for axis in axes],
+            'coordinateTransformations': [{'scale': [1.0, 1.0, 1.0], 'type': 'scale'}],
+            'datasets': [
+                {
+                    'coordinateTransformations': [
+                        {'scale': voxel_size_f, 'type': 'scale'},
+                        {'translation': translation, 'type': 'translation'},
+                    ],
+                    'path': ds_name,
+                }
+            ],
+            'name': 'amira_export',
+        }
 
-        p = Path(group_dir)
+        fmt = 3 if zarr_version == 'v3' else 2
+        grp = zarr.open_group(str(group_dir), mode='a', zarr_format=fmt)
         if zarr_version == 'v3':
-            zarr_json_path = p / 'zarr.json'
-            if zarr_json_path.exists():
-                meta = json.loads(zarr_json_path.read_text())
-            else:
-                meta = {'zarr_format': 3, 'node_type': 'group'}
-            meta['attributes'] = {'ome': {'version': '0.5', **attrs}}
-            zarr_json_path.write_text(json.dumps(meta, indent=2))
+            grp.attrs.update({'ome': {'version': '0.5', 'multiscales': [multiscales_entry]}})
         else:
-            attrs['multiscales'][0]['version'] = '0.4'
-            (p / '.zattrs').write_text(json.dumps(attrs, indent=2))
+            multiscales_entry['version'] = '0.4'
+            grp.attrs.update({'multiscales': [multiscales_entry]})

--- a/ZarrWrite.pyscro
+++ b/ZarrWrite.pyscro
@@ -87,15 +87,24 @@ class ZarrWrite(PyScriptObject):
     def __init__(self):
         self.data.valid_types = ['HxUniformScalarField3']
         self.do_it = HxPortDoIt(self, 'write', 'Save Zarr')
+        self.do_it.position = 4
         self.output_dir = HxPortFilename(self, 'outputDir', 'Output Directory')
         self.output_dir.mode = HxPortFilename.LOAD_DIRECTORY
+        self.output_dir.position = 1
         self.zarr_format = HxPortMultiMenu(self)
         self.zarr_format.menus = [
             HxPortButtonMenu.Menu(options=['Zarr v2', 'Zarr v3']),
         ]
         self.zarr_format.name = 'zarrFormat'
         self.zarr_format.label = 'Zarr Format'
-        self.zarr_format.position = 1
+        self.zarr_format.position = 2
+        self.units_menu = HxPortMultiMenu(self)
+        self.units_menu.menus = [
+            HxPortButtonMenu.Menu(options=['nanometer', 'micrometer', 'millimeter']),
+        ]
+        self.units_menu.name = 'voxelUnits'
+        self.units_menu.label = 'Voxel Units'
+        self.units_menu.position = 3
         self.container_path = None
         self.dataset_path = None
 
@@ -147,6 +156,9 @@ class ZarrWrite(PyScriptObject):
     def selected_zarr_version(self) -> str:
         return 'v2' if self.zarr_format.menus[0].selected == 0 else 'v3'
 
+    def selected_unit(self) -> str:
+        return ['nanometer', 'micrometer', 'millimeter'][self.units_menu.menus[0].selected]
+
     def bbox_to_slices(self):
         # convert the bounding box of the input data (real units) to a tuple of slices (indices)
         shape = self.data.source().get_array().shape
@@ -170,11 +182,7 @@ class ZarrWrite(PyScriptObject):
     
     def add_multiscales_metadata(self, group_dir: str, ds_name: str, zarr_version: str):
         axes = ['z', 'y', 'x']
-        try:
-            unit = self.data.source().parameters['units'] or 'nanometer'
-        except Exception:
-            hx_message.error(message='Could not read units from field parameters. Defaulting to nanometer.')
-            unit = 'nanometer'
+        unit = self.selected_unit()
         offset = self.data.source().ports.PhysicalSize.text.split('from')[1].strip().split(', ')[::-1]
         voxel_size = self.data.source().ports.VoxelSize.text.split(' x ')[::-1]
         voxel_size_f = [float(v) for v in voxel_size]


### PR DESCRIPTION
## Summary

Rewrites ZarrRead and ZarrWrite to use the zarr-python 3.x and ome-zarr-models-py APIs, replacing all manual filesystem inspection with library calls. Adds 4D array support, voxel unit round-trip, and several GUI improvements.

### ZarrRead

- **zarr-python 3.x API**: `is_zarr_array` and `open_ts_array` now use `zarr.open()` and `node.metadata.zarr_format` for format detection instead of manual `.zarray`/`zarr.json` file inspection.
- **ome-zarr-models integration**: `check_for_multiscale` replaced by `find_ome_image` (walks up from the selected path to the container root) and `get_resolution_and_offset` now reads voxel size, translation, and units via `image.datasets[0]` and `ds.coordinateTransformations`. Handles both OME-NGFF 0.4 (`multiscales` at root) and 0.5 (`ome.multiscales`) attribute layouts.
- **4D array support**: Channel selector port added; spatial slices and bounding box are computed from the last 3 dimensions; resolution/offset/units are trimmed to 3 elements for 4D inputs.
- **Axis order awareness**: Storage axis order is read from OME-Zarr axes metadata and used for the correct transpose and bounding box calculation instead of assuming z/y/x.
- **Units display**: A read-only "Units" port shows the full units array from OME-Zarr metadata after an array is selected.
- **Units stored on output field**: `result.parameters['units']` is set on the loaded `HxUniformScalarField3`.

### ZarrWrite

- **zarr-python 3.x API**: `is_zarr_array`, `open_ts_array`, and `ensure_group_metadata` use the zarr-python 3.x group/array API (`zarr.open_group(mode='a', zarr_format=N)`) instead of direct JSON file writes.
- **OME-NGFF 0.4/0.5 metadata**: v2 arrays get `multiscales` at the group root (0.4); v3 arrays get `{'ome': {'version': '0.5', 'multiscales': [...]}}` (0.5). Voxel size and translation are read from Amira's `VoxelSize` and `PhysicalSize` ports.
- **Voxel Units dropdown**: Replaces the previous attempt to read units from `HxParamBundle` (unreliable for derived objects). Options: `nanometer`, `micrometer`, `millimeter`; defaults to `nanometer`.
- **Zarr Format dropdown**: Selects between Zarr v2 and v3 output.
- **Port ordering**: Output Directory → Zarr Format → Voxel Units → Save button.
