### PR TITLE
Installation and env setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,14 +36,18 @@ This step has to be done through the Amira GUI because it requires interactive a
 
 1. Download `install_zarr_extensions.bat` from the [Releases](../../releases) page.
 2. Double-click it and approve the UAC prompt so it runs as Administrator.
-3. When prompted, type the name of the EDM environment you just created (e.g. `hxEnv1`) and press Enter.
+3. The script lists every EDM environment under `~/.edm/envs/` as a numbered menu. Type the number of the environment you created (e.g. `hxEnv1`) and press Enter.
 4. The script will:
    - Find the latest Amira installation under `C:\Program Files\`
-   - Verify the chosen EDM environment exists
    - Install the additional Python packages: `zarr==3.1.5`, `numpy==1.26.4`, `ome-zarr-models==1.7`, `tensorstore==0.1.82`
    - Download the extension files from this repository and copy them to `<AmiraRoot>\share\python_script_objects\`
-   - Set the `HX_FORCE_PYTHON_PATH` environment variable to point Amira at the chosen environment
-5. Restart Amira.
+
+#### 3. Activate the environment in Amira
+
+1. Open Amira.
+2. From the menu bar, choose **Developer → Python Environments → Select Python Environment**.
+3. Pick the environment you set up (e.g. `hxEnv1`) from the list.
+4. Restart Amira so the new environment and extensions are loaded.
 
 ## Using the extensions
 

--- a/install_zarr_extensions.bat
+++ b/install_zarr_extensions.bat
@@ -74,7 +74,7 @@ foreach ($file in $Files) {
 # 6. Point Amira at the EDM environment
 Write-Step "Configuring Amira to use EDM environment '$EdmEnv'"
 $EnvPath = "$env:USERPROFILE\.edm\envs\$EdmEnv"
-[System.Environment]::SetEnvironmentVariable("HX_FORCE_PYTHON_PATH", $EnvPath, "Machine")
+[System.Environment]::SetEnvironmentVariable("HX_FORCE_PYTHON_PATH", $EnvPath, "User")
 Write-Host "HX_FORCE_PYTHON_PATH set to: $EnvPath"
 
 Write-Step "Done. Restart Amira to apply changes."

--- a/install_zarr_extensions.bat
+++ b/install_zarr_extensions.bat
@@ -71,10 +71,4 @@ foreach ($file in $Files) {
     Invoke-WebRequest -Uri "$RepoBase/$file" -OutFile $dest -UseBasicParsing
 }
 
-# 6. Point Amira at the EDM environment
-Write-Step "Configuring Amira to use EDM environment '$EdmEnv'"
-$EnvPath = "$env:USERPROFILE\.edm\envs\$EdmEnv"
-[System.Environment]::SetEnvironmentVariable("HX_FORCE_PYTHON_PATH", $EnvPath, "User")
-Write-Host "HX_FORCE_PYTHON_PATH set to: $EnvPath"
-
-Write-Step "Done. Restart Amira to apply changes."
+Write-Step "Done. In Amira, go to Developer -> Python Environments -> Select Python Environment -> '$EdmEnv', then restart."


### PR DESCRIPTION
## Summary

Replaces the automated `HX_FORCE_PYTHON_PATH` step with a manual environment-activation step in Amira's UI. In testing, setting the env var (at either Machine or User scope) did not actually cause Amira to use the chosen environment — the user still had to switch envs through the UI for the extensions to load. Since the env var was effectively a no-op, we drop it and surface the manual step instead.

## Changes

- **`14c82c6`** — Switched `HX_FORCE_PYTHON_PATH` from Machine to User scope to match the old `setx`-based installer. Did not resolve the activation problem on its own, but kept temporarily as a parity step before deciding to drop it.
- **`f162fa4`** — Removed step 6 (the `HX_FORCE_PYTHON_PATH` write) from `install_zarr_extensions.bat`. The final message now tells the user the exact menu path to activate the environment: **Developer → Python Environments → Select Python Environment → `<env>`**.
- **`a215928`** — Reorganized the README install section to reflect the new flow:
  - Updated step 3 of the installer to mention the numbered-list selection (instead of the old name-typing prompt).
  - Dropped the `HX_FORCE_PYTHON_PATH` bullet from the "what the script will do" list.
  - Added a new sub-section **"3. Activate the environment in Amira"** with the menu navigation users now need to do manually.

## Test plan

- [ ] Run `install_zarr_extensions.bat`, complete the package install, then in Amira navigate **Developer → Python Environments → Select Python Environment** and pick the env. Verify `ZarrRead` / `ZarrWrite` show up under Python Scripts after restart.

