### PR TITLE
ome-zarr

### DIFF
--- a/src/extensions/zarr/ZarrWrite.pyscro
+++ b/src/extensions/zarr/ZarrWrite.pyscro
@@ -45,6 +45,7 @@ def create_ts_array(path: str, data: np.ndarray, zarr_version: str = 'v3') -> ts
                     {'name': 'bytes'},
                     {'name': 'zstd', 'configuration': {'level': 3}},
                 ],
+                'dimension_names': ['z', 'y', 'x'],
             },
         }
     else:

--- a/src/extensions/zarr/ZarrWrite.pyscro
+++ b/src/extensions/zarr/ZarrWrite.pyscro
@@ -93,7 +93,7 @@ class ZarrWrite(PyScriptObject):
         self.output_dir.position = 1
         self.zarr_format = HxPortMultiMenu(self)
         self.zarr_format.menus = [
-            HxPortButtonMenu.Menu(options=['Zarr v2', 'Zarr v3']),
+            HxPortButtonMenu.Menu(options=['Zarr v3', 'Zarr v2']),
         ]
         self.zarr_format.name = 'zarrFormat'
         self.zarr_format.label = 'Zarr Format'
@@ -154,7 +154,7 @@ class ZarrWrite(PyScriptObject):
             self.add_multiscales_metadata(group_dir, 's0', zarr_version)
 
     def selected_zarr_version(self) -> str:
-        return 'v2' if self.zarr_format.menus[0].selected == 0 else 'v3'
+        return 'v3' if self.zarr_format.menus[0].selected == 0 else 'v2'
 
     def selected_unit(self) -> str:
         return ['nanometer', 'micrometer', 'millimeter'][self.units_menu.menus[0].selected]

--- a/src/extensions/zarr/ZarrWrite.pyscro
+++ b/src/extensions/zarr/ZarrWrite.pyscro
@@ -3,6 +3,8 @@ import numpy as np
 import os
 import zarr
 from pathlib import Path
+from ome_zarr_models.v04.image import Multiscale as MultiscaleV04
+from ome_zarr_models.v05.image import Multiscale as MultiscaleV05
 _container_extension = '.zarr'
 
 
@@ -204,10 +206,15 @@ class ZarrWrite(PyScriptObject):
             'name': 'amira_export',
         }
 
+        if zarr_version == 'v3':
+            MultiscaleV05.model_validate(multiscales_entry)
+        else:
+            multiscales_entry['version'] = '0.4'
+            MultiscaleV04.model_validate(multiscales_entry)
+
         fmt = 3 if zarr_version == 'v3' else 2
         grp = zarr.open_group(str(group_dir), mode='a', zarr_format=fmt)
         if zarr_version == 'v3':
             grp.attrs.update({'ome': {'version': '0.5', 'multiscales': [multiscales_entry]}})
         else:
-            multiscales_entry['version'] = '0.4'
             grp.attrs.update({'multiscales': [multiscales_entry]})


### PR DESCRIPTION
## Summary

Fixes a Zarr v3 / OME-NGFF v0.5 compliance bug in `ZarrWrite` and adds an in-memory multiscale validation pass so future regressions in our metadata structure are caught before any file I/O. Also flips the format dropdown so Zarr v3 is the default selection.

## Changes

### Default to Zarr v3 in the format dropdown

Swaps the order of options in the Zarr Format `HxPortMultiMenu` so v3 is index 0 (the default selection), with v2 still available as the second option.

### Write `dimension_names` in v3 array metadata

OME-NGFF v0.5 requires that each array's `zarr.json` contain a `dimension_names` field whose entries match the `axes[*].name` values in the parent group's `multiscales` metadata. Without it, the array's dimensions can't be linked to the named axes, and any spec validator (e.g. `ome-zarr-models.open_ome_zarr`) fails the cross-file check.

The v3 spec passed to tensorstore in `create_ts_array` now includes:

```python
'dimension_names': ['z', 'y', 'x']
