### PR TITLE
ZarrRead: shorten Amira error popup to first failure; full error list in the python console

### DIFF
--- a/src/extensions/zarr/ZarrRead.pyscro
+++ b/src/extensions/zarr/ZarrRead.pyscro
@@ -89,12 +89,11 @@ def get_resolution_and_offset(array_dir: str, ndim: int,
     image, ms_dir, errors = ome_result
 
     if image is None:
-        details = '\n'.join('  {0}\n    {1}: {2}'.format(p, t, m) for p, t, m in errors)
-        msg = ('No OME-Zarr multiscales metadata found. '
-               'Using defaults: Resolution={0} nm, Offset={1} nm.\n'
-               'Tried:\n{2}').format(voxel_size, offset, details)
-        hx_message.error(message=msg)
-        print(msg)
+        first = errors[0] if errors else (None, 'NoError', 'no attempts made')
+        hx_message.error(message='No OME-Zarr multiscales found. {0}: {1}'.format(first[1], first[2]))
+        print('No OME-Zarr multiscales metadata found. Using defaults: Resolution={0} nm, Offset={1} nm.'.format(voxel_size, offset))
+        for p, t, m in errors:
+            print('  {0}\n    {1}: {2}'.format(p, t, m))
         return voxel_size, offset, units
 
     print('Found multiscales attributes')


### PR DESCRIPTION
ZarrRead: shorten Amira error popup to first failure; full error list in the python console