### PR TITLE
Ome zarr

### DIFF
--- a/src/extensions/zarr/ZarrWrite.pyscro
+++ b/src/extensions/zarr/ZarrWrite.pyscro
@@ -2,6 +2,7 @@ import tensorstore as ts
 import numpy as np
 import os
 import zarr
+import datetime
 from pathlib import Path
 from ome_zarr_models.v04.image import Multiscale as MultiscaleV04
 from ome_zarr_models.v05.image import Multiscale as MultiscaleV05
@@ -110,15 +111,17 @@ class ZarrWrite(PyScriptObject):
         self.units_menu.position = 3
         self.container_path = None
         self.dataset_path = None
+        self._auto_name_dir = None
 
     def update(self):
         if self.output_dir.is_new and self.output_dir.filenames is not None:
             if '.zarr' in self.output_dir.filenames:
                 self.container_path, self.dataset_path = split_path_at_container(self.output_dir.filenames)
+                self._auto_name_dir = None
             else:
-                dir_path = self.output_dir.filenames
-                self.container_path = self.if_name_exists(dir_path, 'amira_export', 0)
+                self.container_path = None
                 self.dataset_path = ''
+                self._auto_name_dir = self.output_dir.filenames
 
     def compute(self):
         if not self.do_it.was_hit:
@@ -128,7 +131,13 @@ class ZarrWrite(PyScriptObject):
 
         output = self.data.source().get_array().T
         ds_name = self.data.source().name.strip('-')
-        node_path = self.container_path + self.dataset_path
+        if self._auto_name_dir is not None:
+            timestamp = datetime.datetime.now().strftime('%Y-%m-%dT%H-%M-%S')
+            node_path = os.path.join(self._auto_name_dir, 'amira_export_{0}.zarr'.format(timestamp)).replace('\\', '/')
+            self.container_path = node_path
+            self.dataset_path = ''
+        else:
+            node_path = self.container_path + self.dataset_path
 
         zarr_version = self.selected_zarr_version()
         if is_zarr_array(node_path):

--- a/src/extensions/zarr/ZarrWrite.pyscro
+++ b/src/extensions/zarr/ZarrWrite.pyscro
@@ -182,16 +182,6 @@ class ZarrWrite(PyScriptObject):
         return slices
     
 
-    def if_name_exists(self, path, zarr_name, copy_num):
-        if copy_num == 0:
-            zarr_path=os.path.join(path, f"{zarr_name}.zarr").replace("\\","/")
-        else:
-            zarr_path= os.path.join(path,f"{zarr_name}_({copy_num}).zarr").replace("\\","/")
-        if not os.path.exists(zarr_path):
-            return zarr_path
-        else:
-            return self.if_name_exists(path, zarr_name, copy_num+1)
-    
     def add_multiscales_metadata(self, group_dir: str, ds_name: str, zarr_version: str):
         axes = ['z', 'y', 'x']
         unit = self.selected_unit()

--- a/src/extensions/zarr/ZarrWrite.pyscro
+++ b/src/extensions/zarr/ZarrWrite.pyscro
@@ -33,6 +33,12 @@ def open_ts_array(path: str) -> ts.TensorStore:
     }).result()
 
 
+def get_zarr_format(path: str) -> str:
+    """Return 'v3' or 'v2' for the zarr array at path."""
+    node = zarr.open(str(path), mode='r')
+    return 'v3' if node.metadata.zarr_format == 3 else 'v2'
+
+
 def create_ts_array(path: str, data: np.ndarray, zarr_version: str = 'v3') -> ts.TensorStore:
     """Create a new zarr array and write data into it."""
     Path(path).mkdir(parents=True, exist_ok=True)
@@ -141,6 +147,10 @@ class ZarrWrite(PyScriptObject):
 
         zarr_version = self.selected_zarr_version()
         if is_zarr_array(node_path):
+            existing_format = get_zarr_format(node_path)
+            if existing_format != zarr_version:
+                hx_message.error(message='Zarr format mismatch: target is {0} but selected format is {1}.'.format(existing_format, zarr_version))
+                return
             existing = open_ts_array(node_path)
             if tuple(existing.shape) != output.shape:
                 hx_message.error(message='Array dimensions do not match the target dataset.')
@@ -156,6 +166,10 @@ class ZarrWrite(PyScriptObject):
             ensure_group_metadata(node_path, zarr_version)
             ensure_group_metadata(group_dir, zarr_version)
             if is_zarr_array(array_dir):
+                existing_format = get_zarr_format(array_dir)
+                if existing_format != zarr_version:
+                    hx_message.error(message='Zarr format mismatch: target is {0} but selected format is {1}.'.format(existing_format, zarr_version))
+                    return
                 existing = open_ts_array(array_dir)
                 if tuple(existing.shape) != output.shape:
                     hx_message.error(message='Array dimensions do not match the target dataset.')


### PR DESCRIPTION
## Changes

### ZarrWrite: timestamp-suffixed auto-naming

update() only fires when the output dir is freshly picked, so the previous if_name_exists index logic ran exactly once. Repeated clicks of Save Zarr would write to the same amira_export.zarr, silently overwriting the previous export.

Now: when the user picks a non-.zarr parent directory, the path is held as _auto_name_dir and the actual node_path is generated at compute() time as amira_export_YYYY-MM-DDTHH-MM-SS.zarr, so each save produces a fresh file. Picking a specific .zarr (or sub-folder) is unchanged: it is treated as an explicit target the user wants to overwrite.

### Remove if_name_exists

The recursive amira_export_(N).zarr index helper is now dead code; the timestamp scheme guarantees uniqueness without filesystem checks.

### ZarrWrite: reject zarr-format mismatch

Writing zarr v3 data into an existing v2 array (or vice versa) used to succeed silently. open_ts_array auto-detects the existing format, so the user's Zarr Format dropdown was effectively ignored on overwrite. Now both is_zarr_array branches compare the target's actual format against selected_zarr_version() via a new get_zarr_format(path) helper, and surface:

    Zarr format mismatch: target is v2 but selected format is v3.

before any write happens.

