### PR TITLE
install_zarr_extensions: auto-download and install EDM 4.1.0 if missing

### DIFF
--- a/install_zarr_extensions.bat
+++ b/install_zarr_extensions.bat
@@ -29,8 +29,19 @@ $AmiraRoot = Get-ChildItem $ProgramFiles -Directory |
 if (-not $AmiraRoot) { Fail "No Amira installation found under '$ProgramFiles'" }
 Write-Host "Using: $AmiraRoot"
 
-# 2. Verify EDM is present
-if (-not (Test-Path $EdmExe)) { Fail "EDM not found at '$EdmExe'" }
+# 2. Verify EDM is present; download and install if missing
+if (-not (Test-Path $EdmExe)) {
+    Write-Step "EDM not found. Downloading and installing..."
+    $EdmInstallerUrl = "https://assets.enthought.com/downloads/installer/560/edm_4.1.0_win_x86_64.msi"
+    $EdmInstaller = Join-Path $env:TEMP "edm_4.1.0_win_x86_64.msi"
+    Write-Host "Downloading from $EdmInstallerUrl"
+    Invoke-WebRequest -Uri $EdmInstallerUrl -OutFile $EdmInstaller -UseBasicParsing
+    Write-Host "Installing EDM (msiexec /passive)"
+    $proc = Start-Process msiexec.exe -ArgumentList "/i `"$EdmInstaller`" /passive /norestart" -Wait -PassThru
+    if ($proc.ExitCode -ne 0) { Fail "EDM installation failed (msiexec exit $($proc.ExitCode))" }
+    if (-not (Test-Path $EdmExe)) { Fail "EDM was not installed at the expected location: $EdmExe" }
+    Write-Host "EDM installed."
+}
 
 # 3. Ask user which EDM environment to use
 Write-Step "Choose an EDM environment"


### PR DESCRIPTION
## Summary

If EDM is not already installed, install_zarr_extensions.bat now downloads the EDM 4.1.0 MSI and installs it instead of failing out. Lets a fresh-machine user run the installer end-to-end without first having to set up EDM by hand.

## Changes

Step 2 of the installer used to be a single Test-Path / Fail. It now:

1. Tests $EdmExe at the standard location.
2. If missing, downloads edm_4.1.0_win_x86_64.msi from assets.enthought.com (URL: https://assets.enthought.com/downloads/installer/560/edm_4.1.0_win_x86_64.msi) to %TEMP%.
3. Runs msiexec /i ... /passive /norestart so the user sees an install progress bar without having to click through the wizard.
4. Re-checks $EdmExe and fails with a clear error if EDM still is not at the expected location.

The downstream env-selection / package-install / script-deploy steps are unchanged.
