### PR TITLE
Support for 5D data

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,18 +55,21 @@ This step has to be done through the Amira GUI because it requires interactive a
 
 ### ZarrRead
 
-Loads a Zarr array (v2 or v3) into Amira as a `HxUniformScalarField3`.
+Loads a Zarr array (v2 or v3) into Amira as a `HxUniformScalarField3` in `(x, y, z)` axis order (Amira's convention).
 
-- Supports 3D and 4D arrays (4D: select a channel index)
-- Reads OME-NGFF 0.4 and 0.5 metadata for voxel size, translation offset, and axis units
-- Displays array shape and units in the Properties panel
-- Supports partial loading via per-axis start/stop slice controls
+- Works with 3D, 4D, and 5D arrays. For 4D and 5D, pick a Channel and/or Time index in the GUI and ZarrRead loads the matching 3D slab.
+- Time and Channel axes are identified by the OME-NGFF `axes[i].type` field (`time`, `channel`, `space`).
+- If axis types aren't in the metadata, ZarrRead falls back to the common layouts (`(z, y, x)` for 3D, `(c, z, y, x)` for 4D) and pops up an Amira warning so you know we guessed. 5D arrays without axis types are rejected.
+- Spatial axes can be stored in any order (`zyx`, `xyz`, `yzx`, etc.) — ZarrRead reads them in their on-disk order and transposes to `(x, y, z)` for you.
+- Reads OME-NGFF 0.4 and 0.5 metadata for voxel size, translation offset, and axis units.
+- Shows array shape and units in the Properties panel.
+- Supports partial loading via per-axis start/stop slice controls.
 
 Right-click a data object → Python Scripts → `ZarrRead` → Create. Use the Input Directory picker to select a Zarr array folder, then click **Load Zarr**.
 
 ### ZarrWrite
 
-Saves an `HxUniformScalarField3` as a Zarr array with OME-NGFF multiscales metadata.
+Saves an `HxUniformScalarField3` as a Zarr array with OME-NGFF multiscales metadata. The output is always written in `(z, y, x)` axis order on disk (the OME-NGFF canonical convention), regardless of the source axis order — the input field is transposed from Amira's `(x, y, z)` to `(z, y, x)` before writing, and `dimension_names` / `axes` in the metadata are set to `[z, y, x]` to match.
 
 - Writes Zarr v2 or v3 (selectable)
 - Voxel size and translation offset are read from Amira's `VoxelSize` and `PhysicalSize` ports

--- a/src/extensions/zarr/ZarrRead.pyscro
+++ b/src/extensions/zarr/ZarrRead.pyscro
@@ -182,10 +182,13 @@ class ZarrRead(PyScriptObject):
         self._axis_types = None
         self._axis_names = None
         self._spatial_indices = None
+        self._t_axis_idx = None
         self._c_axis_idx = None
 
         self.channel = HxPortIntTextN(self, 'channel', 'Channel')
         self.channel.texts = [HxPortIntTextN.IntText(label='Index', value=0)]
+        self.time = HxPortIntTextN(self, 'time', 'Time')
+        self.time.texts = [HxPortIntTextN.IntText(label='Index', value=0)]
 
         self._dimensions = ('z', 'y', 'x')
         self.slice_textboxes = dict()
@@ -217,8 +220,8 @@ class ZarrRead(PyScriptObject):
                 return
             self.dataset = open_ts_array(self.array_dir)
             ndim = len(self.dataset.shape)
-            if ndim not in (3, 4):
-                hx_message.error(message='Only 3D and 4D arrays are supported (got {0}D).'.format(ndim))
+            if ndim not in (3, 4, 5):
+                hx_message.error(message='Only 3D, 4D, and 5D arrays are supported (got {0}D).'.format(ndim))
                 return
             self.ndim = ndim
             parent_dir = self.container_path if self.dataset_path == '' else str(Path(self.array_dir).parent)
@@ -231,10 +234,7 @@ class ZarrRead(PyScriptObject):
                 hx_message.error(message='Axis layout error: {0}'.format(err))
                 return
             (self._axis_types, self._axis_names, self._spatial_indices,
-             self._storage_axes, t_idx, self._c_axis_idx, assumed_layout) = classified
-            if t_idx is not None:
-                hx_message.error(message='Time axis is not supported for 3D/4D arrays.')
-                return
+             self._storage_axes, self._t_axis_idx, self._c_axis_idx, assumed_layout) = classified
             if assumed_layout:
                 hx_message.warning(message='Axis types not in metadata. Assumed layout: {0}.'.format(assumed_layout))
 
@@ -249,6 +249,10 @@ class ZarrRead(PyScriptObject):
                 self.channel.texts[0].clamp_range = (0, 0)
             else:
                 self.channel.texts[0].clamp_range = (0, self.dataset.shape[self._c_axis_idx] - 1)
+            if self._t_axis_idx is None:
+                self.time.texts[0].clamp_range = (0, 0)
+            else:
+                self.time.texts[0].clamp_range = (0, self.dataset.shape[self._t_axis_idx] - 1)
 
             spatial_shape = tuple(self.dataset.shape[i] for i in self._spatial_indices)
             self.update_info_box()
@@ -268,6 +272,15 @@ class ZarrRead(PyScriptObject):
                 max_ch = self.dataset.shape[self._c_axis_idx] - 1
                 if ch < 0 or ch > max_ch:
                     hx_message.error(message='Channel index out of range. Choose within 0-{0}.'.format(max_ch))
+
+        if self.time.is_new and self.ndim is not None:
+            t = self.time.texts[0].value
+            if self._t_axis_idx is None and t != 0:
+                hx_message.error(message='This array has no time axis; index must be 0.')
+            elif self._t_axis_idx is not None:
+                max_t = self.dataset.shape[self._t_axis_idx] - 1
+                if t < 0 or t > max_t:
+                    hx_message.error(message='Time index out of range. Choose within 0-{0}.'.format(max_t))
 
         # if any of the textboxes have changed, then update the corresponding slices
         if any(s.is_new for s in self.slice_textboxes.values()):
@@ -291,6 +304,7 @@ class ZarrRead(PyScriptObject):
             return
 
         ch = self.channel.texts[0].value
+        t = self.time.texts[0].value
         if self._c_axis_idx is None and ch != 0:
             hx_message.error(message='This array has no channel axis; index must be 0.')
             return
@@ -299,6 +313,14 @@ class ZarrRead(PyScriptObject):
             if ch < 0 or ch > max_ch:
                 hx_message.error(message='Channel index out of range. Choose within 0-{0}.'.format(max_ch))
                 return
+        if self._t_axis_idx is None and t != 0:
+            hx_message.error(message='This array has no time axis; index must be 0.')
+            return
+        if self._t_axis_idx is not None:
+            max_t = self.dataset.shape[self._t_axis_idx] - 1
+            if t < 0 or t > max_t:
+                hx_message.error(message='Time index out of range. Choose within 0-{0}.'.format(max_t))
+                return
         spatial_slices = tuple(self.slices[ax] for ax in self._storage_axes)
         if any(sl.start == sl.stop for sl in spatial_slices):
             hx_message.error(message='Start and stop limits are the same along one of the (X, Y, Z) dimensions.')
@@ -306,7 +328,9 @@ class ZarrRead(PyScriptObject):
         result = hx_project.create('HxUniformScalarField3')
         ts_slices = [None] * self.ndim
         for i, ax_type in enumerate(self._axis_types):
-            if ax_type == 'channel':
+            if ax_type == 'time':
+                ts_slices[i] = t
+            elif ax_type == 'channel':
                 ts_slices[i] = ch
             else:
                 ts_slices[i] = self.slices[self._axis_names[i]]

--- a/src/extensions/zarr/ZarrRead.pyscro
+++ b/src/extensions/zarr/ZarrRead.pyscro
@@ -179,6 +179,10 @@ class ZarrRead(PyScriptObject):
         self.offset = None
         self.units = None
         self._storage_axes = ['z', 'y', 'x']
+        self._axis_types = None
+        self._axis_names = None
+        self._spatial_indices = None
+        self._c_axis_idx = None
 
         self.channel = HxPortIntTextN(self, 'channel', 'Channel')
         self.channel.texts = [HxPortIntTextN.IntText(label='Index', value=0)]
@@ -219,39 +223,49 @@ class ZarrRead(PyScriptObject):
             self.ndim = ndim
             parent_dir = self.container_path if self.dataset_path == '' else str(Path(self.array_dir).parent)
             find_result = find_multiscales(parent_dir, self.container_path)
-            self.resolution, self.offset, self.units = get_resolution_and_offset(self.array_dir, ndim, find_result)
-            display_units = list(self.units)
-            if ndim == 4:
-                self.resolution = self.resolution[-3:]
-                self.offset = self.offset[-3:]
-                self.units = self.units[-3:]
-            else:
-                self.channel.texts[0].clamp_range = (0, 0)
-            self.units_info.text = str(display_units)
 
             multiscales, _, _ = find_result
             axes = (multiscales[0].get('axes') or []) if multiscales else []
-            if axes:
-                all_names = [ax.get('name', '') for ax in axes]
-                self._storage_axes = [n for n in all_names if n in ('x', 'y', 'z')]
-            else:
-                self._storage_axes = ['z', 'y', 'x']
+            classified, err = classify_axes(axes, ndim)
+            if classified is None:
+                hx_message.error(message='Axis layout error: {0}'.format(err))
+                return
+            (self._axis_types, self._axis_names, self._spatial_indices,
+             self._storage_axes, t_idx, self._c_axis_idx, assumed_layout) = classified
+            if t_idx is not None:
+                hx_message.error(message='Time axis is not supported for 3D/4D arrays.')
+                return
+            if assumed_layout:
+                hx_message.warning(message='Axis types not in metadata. Assumed layout: {0}.'.format(assumed_layout))
 
+            self.resolution, self.offset, self.units = get_resolution_and_offset(self.array_dir, ndim, find_result)
+            display_units = list(self.units)
+            self.resolution = [self.resolution[i] for i in self._spatial_indices]
+            self.offset = [self.offset[i] for i in self._spatial_indices]
+            self.units = [self.units[i] for i in self._spatial_indices]
+            self.units_info.text = str(display_units)
+
+            if self._c_axis_idx is None:
+                self.channel.texts[0].clamp_range = (0, 0)
+            else:
+                self.channel.texts[0].clamp_range = (0, self.dataset.shape[self._c_axis_idx] - 1)
+
+            spatial_shape = tuple(self.dataset.shape[i] for i in self._spatial_indices)
             self.update_info_box()
             for dim in self._dimensions:
-                size = self.dataset.shape[-3:][self._storage_axes.index(dim)]
+                size = spatial_shape[self._storage_axes.index(dim)]
                 for tb in self.slice_textboxes[dim].texts:
                     tb.clamp_range = (0, size)
                 self.slice_textboxes[dim].texts[0].value = 0
                 self.slice_textboxes[dim].texts[1].value = size
                 self.slices[dim] = slice(0, size)
-        
+
         if self.channel.is_new and self.ndim is not None:
             ch = self.channel.texts[0].value
-            if self.ndim == 3 and ch != 0:
-                hx_message.error(message='Channel index must be 0 for a 3D array.')
-            elif self.ndim == 4:
-                max_ch = self.dataset.shape[0] - 1
+            if self._c_axis_idx is None and ch != 0:
+                hx_message.error(message='This array has no channel axis; index must be 0.')
+            elif self._c_axis_idx is not None:
+                max_ch = self.dataset.shape[self._c_axis_idx] - 1
                 if ch < 0 or ch > max_ch:
                     hx_message.error(message='Channel index out of range. Choose within 0-{0}.'.format(max_ch))
 
@@ -261,8 +275,8 @@ class ZarrRead(PyScriptObject):
                self.slices[d] = slice(self.slice_textboxes[d].texts[0].value, self.slice_textboxes[d].texts[1].value)
 
     def update_info_box(self):
-        if self.dataset is not None:
-            shape_spatial = self.dataset.shape[-3:]
+        if self.dataset is not None and self._spatial_indices is not None:
+            shape_spatial = tuple(self.dataset.shape[i] for i in self._spatial_indices)
             display_shape = tuple(shape_spatial[self._storage_axes.index(ax)] for ax in ('x', 'y', 'z'))
             self.info.text = '{0} array with shape {1}'.format(self.dataset.dtype.numpy_dtype, display_shape)
         else:
@@ -277,21 +291,26 @@ class ZarrRead(PyScriptObject):
             return
 
         ch = self.channel.texts[0].value
-        if self.ndim == 3 and ch != 0:
-            hx_message.error(message='Channel index must be 0 for a 3D array.')
+        if self._c_axis_idx is None and ch != 0:
+            hx_message.error(message='This array has no channel axis; index must be 0.')
             return
-        if self.ndim == 4:
-            max_ch = self.dataset.shape[0] - 1
+        if self._c_axis_idx is not None:
+            max_ch = self.dataset.shape[self._c_axis_idx] - 1
             if ch < 0 or ch > max_ch:
-                hx_message.error(message='Channel index out of range. Choose within 0–{0}.'.format(max_ch))
+                hx_message.error(message='Channel index out of range. Choose within 0-{0}.'.format(max_ch))
                 return
         spatial_slices = tuple(self.slices[ax] for ax in self._storage_axes)
         if any(sl.start == sl.stop for sl in spatial_slices):
             hx_message.error(message='Start and stop limits are the same along one of the (X, Y, Z) dimensions.')
             return
         result = hx_project.create('HxUniformScalarField3')
-        ts_slices = (ch,) + spatial_slices if self.ndim == 4 else spatial_slices
-        raw = self.dataset[ts_slices].read().result()
+        ts_slices = [None] * self.ndim
+        for i, ax_type in enumerate(self._axis_types):
+            if ax_type == 'channel':
+                ts_slices[i] = ch
+            else:
+                ts_slices[i] = self.slices[self._axis_names[i]]
+        raw = self.dataset[tuple(ts_slices)].read().result()
         perm = [self._storage_axes.index(ax) for ax in ('x', 'y', 'z')]
         array = np.transpose(raw, perm)
 

--- a/src/extensions/zarr/ZarrRead.pyscro
+++ b/src/extensions/zarr/ZarrRead.pyscro
@@ -73,6 +73,55 @@ def find_multiscales(group_path: str, container_root: str) -> Tuple:
         path = str(Path(path).parent)
 
 
+def classify_axes(axes_list, ndim):
+    """Classify OME-NGFF axes by type. Returns
+    ((axis_types, axis_names, spatial_indices, storage_axes, t_idx, c_idx, assumed_layout), None)
+    on success, or (None, error_message) on failure.
+
+    Fallbacks (when axis type metadata is absent):
+      ndim == 3 -> all axes assumed spatial (z, y, x)
+      ndim == 4 -> assume (c, z, y, x) for legacy compatibility
+      ndim == 5 -> rejected (caller errors)
+    assumed_layout is None when types came from metadata, or a string when we guessed.
+    """
+    axis_types = [ax.get('type') for ax in axes_list] if axes_list else [None] * ndim
+    axis_names = [ax.get('name', '') for ax in axes_list] if axes_list else []
+    assumed_layout = None
+
+    if not all(t in ('time', 'channel', 'space') for t in axis_types):
+        if ndim == 5:
+            return None, '5D arrays require axis type metadata (time/channel/space).'
+        elif ndim == 4:
+            axis_types = ['channel', 'space', 'space', 'space']
+            if not axis_names:
+                axis_names = ['c', 'z', 'y', 'x']
+            assumed_layout = '(c, z, y, x)'
+        else:
+            axis_types = ['space', 'space', 'space']
+            if not axis_names:
+                axis_names = ['z', 'y', 'x']
+            assumed_layout = '(z, y, x)'
+
+    t_indices = [i for i, t in enumerate(axis_types) if t == 'time']
+    c_indices = [i for i, t in enumerate(axis_types) if t == 'channel']
+    spatial_indices = [i for i, t in enumerate(axis_types) if t == 'space']
+
+    if len(t_indices) > 1:
+        return None, 'Multiple time axes are not supported.'
+    if len(c_indices) > 1:
+        return None, 'Multiple channel axes are not supported.'
+    if len(spatial_indices) != 3:
+        return None, 'Expected exactly 3 spatial axes, got {0}.'.format(len(spatial_indices))
+
+    storage_axes = [axis_names[i] for i in spatial_indices]
+    if set(storage_axes) != {'x', 'y', 'z'}:
+        return None, 'Spatial axes must be named x, y, z (got {0}).'.format(storage_axes)
+
+    t_idx = t_indices[0] if t_indices else None
+    c_idx = c_indices[0] if c_indices else None
+    return (axis_types, axis_names, spatial_indices, storage_axes, t_idx, c_idx, assumed_layout), None
+
+
 def get_resolution_and_offset(array_dir: str, ndim: int,
                                find_result: Tuple) -> Tuple[List[float], List[float], List[str]]:
     voxel_size = [1.0] * ndim


### PR DESCRIPTION
## Summary

Adds 5D OME-NGFF support to ZarrRead and a test-data generator. The read path now works for any combination of time, channel, and spatial axes in any storage order, identified strictly from the OME-NGFF axes type field with sensible fallbacks for 3D and 4D files that lack type metadata.

## Changes

### ZarrRead: 5D support and axis-type-aware slicing

- New top-level helper classify_axes that turns the multiscales axes list into a structured layout: axis_types, axis_names, spatial_indices, storage_axes, time-axis index, channel-axis index, and an assumed_layout marker.
- Strict identification by axes type field (time, channel, space). 5D arrays without type metadata are rejected with a clear error.
- Fallbacks for missing type metadata: 3D defaults to (z, y, x); 4D defaults to (c, z, y, x) to preserve legacy behavior. When a fallback is used, an Amira warning popup tells the user the assumed layout so they know we guessed.
- Existing 3D/4D paths refactored to use classify_axes instead of hardcoded ndim==4 branches.
- New Time port mirrors the existing Channel port. Both are clamped to (0, 0) when their corresponding axis is absent, otherwise to the axis range. Both are validated on every change.
- Resolution, offset, and units are filtered to spatial axes only, using the spatial indices returned by classify_axes (replaces the hardcoded self.resolution[-3:]).
- compute() builds the read slice position-aware by iterating the axis types and inserting the time or channel index or the spatial slice at each position. After tensorstore reads, integer indices collapse the non-spatial axes and the remaining 3D array is transposed to Amira's (x, y, z) using the same axis-name-keyed perm that already worked for arbitrary spatial orderings.

### README

- ZarrRead section now documents 3D / 4D / 5D support, the axis-type identification, the fallback warnings for files without type metadata, the arbitrary-spatial-order support, and the (x, y, z) output convention.
- ZarrWrite section now explicitly calls out the canonical (z, y, x) on-disk axis order it always writes.

