### PR TITLE
Raising an error message when values are out of range; GUI fields order

### DIFF
--- a/src/extensions/zarr/ZarrRead.pyscro
+++ b/src/extensions/zarr/ZarrRead.pyscro
@@ -163,7 +163,7 @@ def get_resolution_and_offset(array_dir: str, ndim: int,
     return voxel_size, offset, units
 
 class ZarrRead(PyScriptObject):
-    def __init__(self):        
+    def __init__(self):
         self.data.valid_types = ['HxUniformScalarField3']
         self.do_it = HxPortDoIt(self, 'read', 'Load Zarr')
         self.input_dir = HxPortFilename(self, 'inputDir', 'Input Directory')
@@ -207,6 +207,20 @@ class ZarrRead(PyScriptObject):
 
         self.slices = {d: slice(0, 1) for d in self._dimensions}
         self._spatial_size = {d: 0 for d in self._dimensions}
+
+        # GUI display order (top to bottom).
+        for pos, port in enumerate([
+            self.input_dir,
+            self.info,
+            self.units_info,
+            self.slice_textboxes['x'],
+            self.slice_textboxes['y'],
+            self.slice_textboxes['z'],
+            self.channel,
+            self.time,
+            self.do_it,
+        ], start=1):
+            port.position = pos
     
 
     def update(self):

--- a/src/extensions/zarr/ZarrRead.pyscro
+++ b/src/extensions/zarr/ZarrRead.pyscro
@@ -245,14 +245,10 @@ class ZarrRead(PyScriptObject):
             self.units = [self.units[i] for i in self._spatial_indices]
             self.units_info.text = str(display_units)
 
-            if self._c_axis_idx is None:
-                self.channel.texts[0].clamp_range = (0, 0)
-            else:
-                self.channel.texts[0].clamp_range = (0, self.dataset.shape[self._c_axis_idx] - 1)
-            if self._t_axis_idx is None:
-                self.time.texts[0].clamp_range = (0, 0)
-            else:
-                self.time.texts[0].clamp_range = (0, self.dataset.shape[self._t_axis_idx] - 1)
+            # No clamp_range on channel/time ports - we want validation warnings
+            # to fire when the user types out-of-range values, not silent clipping.
+            self.channel.texts[0].value = 0
+            self.time.texts[0].value = 0
 
             spatial_shape = tuple(self.dataset.shape[i] for i in self._spatial_indices)
             self.update_info_box()

--- a/src/extensions/zarr/ZarrRead.pyscro
+++ b/src/extensions/zarr/ZarrRead.pyscro
@@ -206,6 +206,7 @@ class ZarrRead(PyScriptObject):
                                                                       value=0)]
 
         self.slices = {d: slice(0, 1) for d in self._dimensions}
+        self._spatial_size = {d: 0 for d in self._dimensions}
     
 
     def update(self):
@@ -254,8 +255,8 @@ class ZarrRead(PyScriptObject):
             self.update_info_box()
             for dim in self._dimensions:
                 size = spatial_shape[self._storage_axes.index(dim)]
-                for tb in self.slice_textboxes[dim].texts:
-                    tb.clamp_range = (0, size)
+                self._spatial_size[dim] = size
+                # No clamp_range - we want validation warnings for out-of-range typing.
                 self.slice_textboxes[dim].texts[0].value = 0
                 self.slice_textboxes[dim].texts[1].value = size
                 self.slices[dim] = slice(0, size)
@@ -281,7 +282,14 @@ class ZarrRead(PyScriptObject):
         # if any of the textboxes have changed, then update the corresponding slices
         if any(s.is_new for s in self.slice_textboxes.values()):
             for d in self._dimensions:
-               self.slices[d] = slice(self.slice_textboxes[d].texts[0].value, self.slice_textboxes[d].texts[1].value)
+                start = self.slice_textboxes[d].texts[0].value
+                stop = self.slice_textboxes[d].texts[1].value
+                size = self._spatial_size[d]
+                if start < 0 or start > size or stop < 0 or stop > size:
+                    hx_message.error(message='{0} slice [{1}:{2}] out of range (must be within [0, {3}]).'.format(d.upper(), start, stop, size))
+                elif start > stop:
+                    hx_message.error(message='{0} slice start ({1}) must be <= stop ({2}).'.format(d.upper(), start, stop))
+                self.slices[d] = slice(start, stop)
 
     def update_info_box(self):
         if self.dataset is not None and self._spatial_indices is not None:
@@ -316,6 +324,15 @@ class ZarrRead(PyScriptObject):
             max_t = self.dataset.shape[self._t_axis_idx] - 1
             if t < 0 or t > max_t:
                 hx_message.error(message='Time index out of range. Choose within 0-{0}.'.format(max_t))
+                return
+        for d in self._dimensions:
+            sl = self.slices[d]
+            size = self._spatial_size[d]
+            if sl.start < 0 or sl.start > size or sl.stop < 0 or sl.stop > size:
+                hx_message.error(message='{0} slice [{1}:{2}] out of range (must be within [0, {3}]).'.format(d.upper(), sl.start, sl.stop, size))
+                return
+            if sl.start > sl.stop:
+                hx_message.error(message='{0} slice start ({1}) must be <= stop ({2}).'.format(d.upper(), sl.start, sl.stop))
                 return
         spatial_slices = tuple(self.slices[ax] for ax in self._storage_axes)
         if any(sl.start == sl.stop for sl in spatial_slices):


### PR DESCRIPTION
## Summary

Replaces silent `clamp_range` clipping on ZarrRead's numeric ports with explicit validation popups, and adds an explicit GUI port display order so the panel reads top-to-bottom in a sensible flow.

## Changes

### ZarrRead: drop clamp_range on Channel/Time ports so out-of-range typing fires the validation warning

Channel and Time ports previously had `clamp_range` set on their text fields. Amira clips the typed value to the range *before* the `is_new` event fires, so the validation block that checks `ch > max_ch` never actually ran — the user typed `999`, saw `5`, and got no feedback. Removed both `clamp_range` lines; the port now accepts any integer, and the existing validation in `update()` and `compute()` fires the Amira error popup with a clear "Channel index out of range. Choose within 0-N." message. Channel and Time are also reset to 0 on every new dataset load so the user starts from a sensible baseline rather than carrying over stale values from a previous file.

### ZarrRead: drop clamp_range on slice text boxes and validate slice ranges

Same silent-clipping problem on the X/Y/Z `Start`/`Stop` text boxes — but worse, since there was no validation logic for slice values at all. Added `self._spatial_size` state (per-axis size in storage axis order), removed the `tb.clamp_range = (0, size)` loop, and added validation in two places:

- In the `is_new` block of `update()`: pops an Amira error if any axis has `start < 0`, `start > size`, `stop < 0`, `stop > size`, or `start > stop`. Fires immediately when the user commits a value.
- In `compute()`: re-checks the same conditions before calling tensorstore, as a last-line-of-defense for values that may have been set programmatically.

Error messages identify the offending axis explicitly (e.g. `X slice [10:999] out of range (must be within [0, 50]).`).

### ZarrRead: set explicit GUI port display order

Ports were previously laid out by creation order in `__init__`, which put the slice text boxes in `(z, y, x)` order and Channel/Time before the slice controls. Added a single `enumerate`/`port.position = ...` block at the end of `__init__` that lists ports in the desired display order (`Input Directory → Array Info → Units → X Limits → Y Limits → Z Limits → Channel → Time → Load Zarr`). Centralized in one place so reordering later is a one-line shuffle. Also cleaned up the trailing whitespace on the `def __init__(self):` line.


