### PR TITLE
ZarrRead: set wide clamp_range on IntText ports so typed out-of-range…

### DIFF
--- a/src/extensions/zarr/ZarrRead.pyscro
+++ b/src/extensions/zarr/ZarrRead.pyscro
@@ -5,6 +5,12 @@ import os
 import zarr
 from typing import List, Tuple, Optional
 _container_extension = '.zarr'
+# Wide clamp_range upper bound for IntText ports. Amira's default cap is 10,
+# which clips typed values before our validation can see them. We set a wide
+# clamp here so the typed value reaches our per-dataset validation in update()
+# and compute(), which then produces a correct error message citing the actual
+# axis size.
+INT_MAX = 2**31 - 1
 
 def split_path_at_container(path: str):
     # check whether a path contains a valid file path to a container file, and if so which container format it is
@@ -191,8 +197,10 @@ class ZarrRead(PyScriptObject):
 
         self.channel = HxPortIntTextN(self, 'channel', 'Channel')
         self.channel.texts = [HxPortIntTextN.IntText(label='Index', value=0)]
+        self.channel.texts[0].clamp_range = (0, INT_MAX)
         self.time = HxPortIntTextN(self, 'time', 'Time')
         self.time.texts = [HxPortIntTextN.IntText(label='Index', value=0)]
+        self.time.texts[0].clamp_range = (0, INT_MAX)
 
         self._dimensions = ('z', 'y', 'x')
         self.slice_textboxes = dict()
@@ -208,6 +216,8 @@ class ZarrRead(PyScriptObject):
                                                                       value=0),
                                                HxPortIntTextN.IntText(label="Stop",
                                                                       value=0)]
+            for tb in self.slice_textboxes[dim].texts:
+                tb.clamp_range = (0, INT_MAX)
 
         self.slices = {d: slice(0, 1) for d in self._dimensions}
         self._spatial_size = {d: 0 for d in self._dimensions}


### PR DESCRIPTION
## Summary

Make ZarrRead's numeric ports actually surface "value out of range" errors instead of silently clipping typed values.


`HxPortIntTextN.IntText` has a default `clamp_range` of `(0, 10)` when none is set explicitly. The previous commits removed the per-dataset `clamp_range` so the validation block in `update()` could see typed values like `999`, but instead Amira clipped them down to `10` before our code ran. The popup that fired then said *"must be within [0, 10]"* — wrong, misleading, and unrelated to the actual axis size.

There's no way to read the typed value *before* Amira's clip, so the only path to a correct error is to widen the clamp enough that typical user input survives intact to the validation step.

## Fix

Set `clamp_range = (0, INT_MAX)` once at `__init__` on Channel, Time, and both Start/Stop boxes of every X/Y/Z slice port:

```python
INT_MAX = 2**31 - 1
...
self.channel.texts[0].clamp_range = (0, INT_MAX)
self.time.texts[0].clamp_range = (0, INT_MAX)
for tb in self.slice_textboxes[dim].texts:
    tb.clamp_range = (0, INT_MAX)
```

Per-dataset code is unchanged: it still resets values to 0 and updates `_spatial_size`, and the existing validation in `update()` and `compute()` checks against the actual axis size, now producing accurate error messages like *"Channel index out of range. Choose within 0-3."*

