### PR TITLE
add Axis order info and full shape of the array 

### DIFF
--- a/src/extensions/zarr/ZarrRead.pyscro
+++ b/src/extensions/zarr/ZarrRead.pyscro
@@ -179,6 +179,7 @@ class ZarrRead(PyScriptObject):
         self.input_dir = HxPortFilename(self, 'inputDir', 'Input Directory')
         self.input_dir.mode = HxPortFilename.LOAD_DIRECTORY
         self.info = HxPortInfo(self, 'array_info', 'Array Info')
+        self.axes_info = HxPortInfo(self, 'axes_info', 'Axes order')
         self.units_info = HxPortInfo(self, 'units_info', 'Units')
         self.dataset = None
         self.container_path = None
@@ -226,6 +227,7 @@ class ZarrRead(PyScriptObject):
         for pos, port in enumerate([
             self.input_dir,
             self.info,
+            self.axes_info,
             self.units_info,
             self.slice_textboxes['x'],
             self.slice_textboxes['y'],
@@ -320,10 +322,12 @@ class ZarrRead(PyScriptObject):
                 self.slices[d] = slice(start, stop)
 
     def update_info_box(self):
-        if self.dataset is not None:
+        if self.dataset is not None and self._axis_names is not None:
             self.info.text = '{0} array with shape {1}'.format(self.dataset.dtype.numpy_dtype, tuple(self.dataset.shape))
+            self.axes_info.text = '({0})'.format(', '.join(self._axis_names))
         else:
             self.info.text = 'No array selected'
+            self.axes_info.text = ''
 
     def compute(self):
         

--- a/src/extensions/zarr/ZarrRead.pyscro
+++ b/src/extensions/zarr/ZarrRead.pyscro
@@ -179,7 +179,7 @@ class ZarrRead(PyScriptObject):
         self.input_dir = HxPortFilename(self, 'inputDir', 'Input Directory')
         self.input_dir.mode = HxPortFilename.LOAD_DIRECTORY
         self.info = HxPortInfo(self, 'array_info', 'Array Info')
-        self.axes_info = HxPortInfo(self, 'axes_info', 'Axes order')
+        self.axes_info = HxPortInfo(self, 'axes_info', 'Axis Order')
         self.units_info = HxPortInfo(self, 'units_info', 'Units')
         self.dataset = None
         self.container_path = None

--- a/src/extensions/zarr/ZarrRead.pyscro
+++ b/src/extensions/zarr/ZarrRead.pyscro
@@ -178,7 +178,7 @@ class ZarrRead(PyScriptObject):
         self.do_it = HxPortDoIt(self, 'read', 'Load Zarr')
         self.input_dir = HxPortFilename(self, 'inputDir', 'Input Directory')
         self.input_dir.mode = HxPortFilename.LOAD_DIRECTORY
-        self.info = HxPortInfo(self, 'array_info', 'Array info')
+        self.info = HxPortInfo(self, 'array_info', 'Array Info')
         self.units_info = HxPortInfo(self, 'units_info', 'Units')
         self.dataset = None
         self.container_path = None
@@ -320,10 +320,8 @@ class ZarrRead(PyScriptObject):
                 self.slices[d] = slice(start, stop)
 
     def update_info_box(self):
-        if self.dataset is not None and self._spatial_indices is not None:
-            shape_spatial = tuple(self.dataset.shape[i] for i in self._spatial_indices)
-            display_shape = tuple(shape_spatial[self._storage_axes.index(ax)] for ax in ('x', 'y', 'z'))
-            self.info.text = '{0} array with shape {1}'.format(self.dataset.dtype.numpy_dtype, display_shape)
+        if self.dataset is not None:
+            self.info.text = '{0} array with shape {1}'.format(self.dataset.dtype.numpy_dtype, tuple(self.dataset.shape))
         else:
             self.info.text = 'No array selected'
 


### PR DESCRIPTION
## Summary

Improve the ZarrRead info display: Array Info now shows the full on-disk shape (not just the spatial slab), and a new Axes order port shows what each storage position means.

## Problem

Previously, Array Info showed only the spatial portion of the array shape in (x, y, z) order. For a 5D `(t=4, c=3, z=584, y=940, x=367)` file it read `uint32 array with shape (367, 940, 584)` — which is what the loaded HxUniformScalarField3 ends up being, but tells you nothing about the file: not the dimensionality, not the channel/time counts, not the axis order. You had to cross-reference the Channel and Time port clamp ranges to piece any of that together.

## Fix

### Array Info now shows the full shape

```python
self.info.text = '{0} array with shape {1}'.format(
    self.dataset.dtype.numpy_dtype, tuple(self.dataset.shape))
```

For the same 5D file the line now reads:

```
uint32 array with shape (4, 3, 584, 940, 367)
```

Also fixed the label from "Array info" to "Array Info" for consistency with the other capitalized port labels.

### New Axes order info port

To make the meaning of each storage position obvious, a second `HxPortInfo` is shown right below Array Info:

```python
self.axes_info = HxPortInfo(self, 'axes_info', 'Axes order')
...
self.axes_info.text = '({0})'.format(', '.join(self._axis_names))
```

For the same file:

```
(t, c, z, y, x)
```

The axis names come straight from `self._axis_names`, which is populated by `classify_axes` from the OME-NGFF axes metadata (or its fallback). This also serves as a quick confirmation that classify_axes interpreted the file the way you expect.

Slotted into the GUI display order between Array Info and Units.